### PR TITLE
Fix random-partner matching in random treatments

### DIFF
--- a/compound_besar_random_fixed/Bargain.html
+++ b/compound_besar_random_fixed/Bargain.html
@@ -1,0 +1,185 @@
+{{ block title }}
+Pelaporan Pajak<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+
+<!-- Minimal CSS styling for a cleaner look -->
+<style>
+    .section-box {
+        margin-bottom: 1.5em;
+        padding: 1em;
+        background-color: #f9f9f9;
+        border: 1px solid #ddd;
+        border-radius: 5px;
+        line-height: 1.5;
+    }
+    .section-box h2 {
+        margin-top: 0;
+    }
+    .section-box ul {
+        margin-top: 0.5em;
+        margin-bottom: 0.5em;
+        padding-left: 1.5em;
+    }
+    .negotiation-table {
+        border-collapse: collapse;
+        width: 100%;
+        margin-top: 1em;
+    }
+    .negotiation-table th,
+    .negotiation-table td {
+        border: 1px solid #ccc;
+        padding: 0.5em;
+    }
+    .debug-section {
+        margin-top: 1em;
+        padding: 0.5em;
+        background-color: #fefefe;
+        border: 1px dashed #ccc;
+    }
+</style>
+
+{{ if player.role == "Importir" }}
+<div class="section-box">
+    <h2>Importir</h2>
+    <p>
+        Anda merupakan importir barang mewah yang berpotensi meraih keuntungan.
+        Saat ini, Anda mengimpor sejumlah <strong>{{ quantity }}</strong> unit.
+        Nilai barang = jumlah barang × harga (20 poin), sehingga nilai barang Anda adalah <strong>{{ player.goods_value }}</strong> poin.
+    </p>
+    <p>
+        Apabila barang dikategorikan sebagai <em>Barang Mewah</em>, tarif dihitung sebagai:
+        <br>
+        (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).
+        <br>
+        Nilai tarif barang mewah adalah <strong>{{ mewah_tariff }}</strong> poin.
+    </p>
+    <p>
+        Anda dapat bernegosiasi dengan petugas pajak untuk mengubah kategori menjadi <em>Barang Biasa</em>, sehingga tarif dihitung sebagai:
+        <br>
+        (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).
+        <br>
+        Nilai tarif barang biasa adalah <strong>{{ biasa_tariff }}</strong> poin.
+        Hasil kesepakatan Anda dengan petugas pajak tidak menjamin kategori akan berubah karena keputusan akhir ada di petugas pajak.
+    </p>
+    <p>
+        Jika terjadi audit (50:50) dan ditemukan ketidaksesuaian, maka denda sebesar 1.5 × nilai tarif akan dikenakan ke Anda.
+    </p>
+</div>
+{{ endif }}
+
+{{ if player.role == "Petugas Pajak" }}
+<div class="section-box">
+    <h2>Petugas Pajak</h2>
+    <p>
+        Anda merupakan petugas pajak impor dengan gaji <strong>{{C.SALARY}}</strong> poin.
+        Anda menentukan kategori barang (Mewah/Barang Biasa) dan menghitung tarif berikut:
+    </p>
+    <ul>
+        <li><em>Barang Mewah</em>: (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).</li>
+        <li><em>Barang Biasa</em>: (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).</li>
+    </ul>
+    <p>
+        Saat ini, jumlah barang mewah yang diimpor adalah sebanyak <strong>{{ quantity }}</strong> unit dengan nilai sebesar <strong>{{ player.goods_value }}</strong> poin.
+        Apabila barang dikategorikan sebagai <em>Barang Mewah</em>, maka nilai tarif = <strong>{{ mewah_tariff }}</strong> poin.
+        Apabila barang dikategorikan sebagai <em>Barang Biasa</em>, maka nilai tarif = <strong>{{ biasa_tariff }}</strong> poin.
+    </p>
+    <p>
+        Importir memiliki potensi keuntungan dan dapat menawarkan transfer kepada Anda agar barang dikategorikan sebagai Barang Biasa.
+        Namun, keputusan akhir ada di tangan Anda.
+        Jika terjadi audit (50:50) dan ditemukan ketidaksesuaian, maka denda sebesar 50% gaji akan dikenakan ke Anda.
+    </p>
+</div>
+{{ endif }}
+
+<p>
+    Silakan bernegosiasi dengan {{ other_role }} mengenai besaran transfer. Jika tidak tercapai kesepakatan,
+    tarif impor akan dikenakan penuh sesuai kategori awal, tanpa transfer.
+</p>
+
+<table class="negotiation-table">
+    <tr>
+        <th>Proposal Transfer Anda</th>
+        <td id="my-proposal">(none)</td>
+        <td>
+            <input type="number" id="my_offer">
+            <button type="button" onclick="sendOffer()" id="btn-offer">Ajukan Transfer</button>
+        </td>
+    </tr>
+
+    <tr>
+        <th>Proposal Transfer {{ other_role }}</th>
+        <td id="other-proposal">(none)</td>
+{{ if player.role == "Petugas Pajak" }}
+        <td>
+            <button type="button" id="btn-accept" onclick="sendAccept(this)" style="display: none">Terima</button>
+        </td>
+        <td>
+            <button type="button" id="btn-reject" onclick="sendReject(this)" style="display: none">Tolak</button>
+        </td>
+    </tr>
+{{ endif }}
+</table>
+
+<h4>Chat</h4>
+{{ chat nickname=player.role }}
+
+<!-- No changes to JavaScript below -->
+<script>
+    let my_offer = document.getElementById('my_offer');
+    let btnAccept = document.getElementById('btn-accept');
+    let btnReject = document.getElementById('btn-reject');
+    let msgOtherProposal = document.getElementById('other-proposal');
+    let msgMyProposal = document.getElementById('my-proposal');
+
+    let otherProposal;
+
+    my_offer.addEventListener("keydown", function (event) {
+        if (event.key === "Enter") {
+            sendOffer();
+        }
+    });
+
+    function sendOffer() {
+        liveSend({'type': 'propose', 'amount': my_offer.value})
+        my_offer.value = '';
+    }
+
+    function sendAccept() {
+        liveSend({'type': 'accept', 'amount': otherProposal})
+    }
+
+    function sendReject() {
+        liveSend({'type': 'reject', 'amount': otherProposal})
+    }
+
+    function cu(amount) {
+        return `${amount} poin`;
+    }
+
+    function liveRecv(data) {
+        if ('proposals' in data) {
+            for (let [id_in_group, proposal] of data.proposals) {
+                if (id_in_group === js_vars.my_id) {
+                    msgMyProposal.innerHTML = cu(proposal);
+                } else {
+                    msgOtherProposal.innerHTML = cu(proposal);
+                    otherProposal = proposal;
+                    btnAccept.style.display = 'block';
+                    btnReject.style.display = 'block';
+                }
+            }
+        }
+        if ('finished' in data) {
+            document.getElementById('form').submit();
+        }
+    }
+
+    window.addEventListener('DOMContentLoaded', (event) => {
+        liveSend({});
+    });
+</script>
+
+{{ endblock }}

--- a/compound_besar_random_fixed/Instructions.html
+++ b/compound_besar_random_fixed/Instructions.html
@@ -1,0 +1,11 @@
+{{ block title }}
+    Sesi Dimulai
+{{ endblock }}
+{{ block content }}
+    Anda akan memasuki sesi yang sebenarnya, keputusan Anda akan berdampak kepada pendapatan Anda di akhir sesi.
+        Anda akan terhubung dengan petugas atau importir yang sama selama sesi eksperimen. Selamat menjalankan eksperimen.
+
+{{ next_button }}
+
+
+{{ endblock }}

--- a/compound_besar_random_fixed/Investigation.html
+++ b/compound_besar_random_fixed/Investigation.html
@@ -1,0 +1,44 @@
+{{ block title }}
+   Hasil<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+
+{% if group.audit == True and group.category == "Barang Biasa" %}
+<p>
+    Hasil audit menemukan ketidaksesuaian pada pelaporan kategori.
+    Denda sebesar <strong>{{ player.penalty }} poin</strong> diberlakukan, <br>
+    {{ if player.role == "Importir" }}
+    Pendapatan akhir Anda adalah = Nilai Barang ({{ player.goods_value }}) - Biaya tarif ({{ player.tariff }}) - Kesepakatan transfer ({{ group.deal_price }}) - Denda ({{ player.penalty }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+    {{ if player.role == "Petugas Pajak" }}
+    Pendapatan akhir Anda adalah Gaji ({{C.SALARY}}) + Kesepakatan transfer ({{ group.deal_price }}) - Transfer ke auditor ({{player.bribe}}) - Denda ({{ player.penalty }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+</p>
+{% endif %}
+
+{% if group.audit == False or group.category == "Barang Mewah" %}
+<p>
+    Tidak ditemukan ketidaksesuaian dalam laporan Anda.
+    Total Tarif yang berlaku adalah = {{ player.tariff }} poin.<br>
+    {{ if player.role == "Importir" }}
+    Pendapatan akhir Anda adalah Nilai Barang ({{ player.goods_value }}) - Biaya tarif ({{ player.tariff }}) - Kesepakatan transfer ({{ group.deal_price }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+    {{ if player.role == "Petugas Pajak" }}
+    Pendapatan akhir Anda adalah Gaji ({{C.SALARY}}) + Kesepakatan transfer ({{ group.deal_price }}) - Transfer ke auditor ({{player.bribe}}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+</p>
+{% endif %}
+
+<hr>
+<p>
+    <strong>Jumlah Barang Diimpor:</strong> {{ group.quantity }}<br>
+    <strong>Kategori Barang Impor Dari Petugas: </strong> {{ group.category }}<br>
+    <strong>Total Tarif yang berlaku adalah = {{ player.tariff }}</strong><br>
+    <strong>Denda Saat Ini:</strong> {{ player.penalty }} poin
+</p>
+
+{{ next_button }}
+
+{{ endblock }}

--- a/compound_besar_random_fixed/Results.html
+++ b/compound_besar_random_fixed/Results.html
@@ -1,0 +1,42 @@
+{{ block title }}
+    Pengambilan Keputusan<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+<p>
+    Kategori apa yang akan Anda berikan kepada barang impor tersebut?
+    {{ formfield 'category' }}
+</p>
+
+Nilai Barang = {{ player.goods_value }} poin<br>
+Tarif barang mewah = (jumlah barang × 3) +(jumlah barang × harga barang (20 poin) × 20%) = {{ player.mewah_tariff }} poin<br>
+Tarif barang biasa = (jumlah barang × 2) +(jumlah barang × harga barang (20 poin) × 15%) = {{ player.biasa_tariff }} poin<br>
+
+{{ if group.deal_price == 0 }}
+<p>
+    Tidak ada negosiasi, sehingga Anda tidak menerima transfer dari importir.
+</p>
+{{ next_button }}
+{{ endif }}
+<br><br>
+
+{{ if group.deal_price > 0 }}
+<p>
+    Anda menyepakati untuk menerima transfer sebesar <strong>{{ group.deal_price }} poin</strong>.
+</p>
+<p>
+    Kegiatan ini memiliki kemungkinan audit 50:50. Jika audit menemukan ketidaksesuaian,
+    denda sebesar <strong>{{ player.potential_penalty }} poin</strong> akan dikenakan pada pendapatan importir dan petugas pajak.
+</p>
+<p>
+    Anda juga berkesempatan memberikan transfer kepada auditor untuk mengurangi risiko audit. Setiap 1 poin yang dikirim petugas ke auditor akan menurunkan peluang audit sebesar 0.2% dan kemungkinan
+              terendah Anda akan terkena audit adalah 10%.
+</p>
+{{ formfield 'bribe' }}
+{{ next_button }}
+{{ endif }}
+
+<hr>
+
+{{ endblock }}

--- a/compound_besar_random_fixed/Results2.html
+++ b/compound_besar_random_fixed/Results2.html
@@ -1,0 +1,12 @@
+{{ block title }}
+    Anda telah menyelesaikan ronde terakhir pada sesi ini
+{{ endblock }}
+{{ block content }}
+Setelah dilakukan pengacakan, terpilih ronde {{selected_round}} sebagai ronde pembyaran Anda pada sesi ini. <br>
+Hasil Anda pada ronde tersebut adalah {{pay_in_selected_round}} poin. Poin ini dikalikan Rp50 rupiah untuk pembayaran eksperimen yaitu {{pay_in_selected_round}} x 50 + uang kehadiran Rp15000 = {{final_payoff}} <br><br>
+<button>
+    Lanjut
+</button><p></p>
+
+{{ endblock }}
+

--- a/compound_besar_random_fixed/__init__.py
+++ b/compound_besar_random_fixed/__init__.py
@@ -1,0 +1,324 @@
+from otree.api import *
+import random
+import math
+
+doc = """
+For oTree beginners, it would be simpler to implement this as a discrete-time game 
+by using multiple rounds, e.g. 10 rounds, where in each round both players can make a new proposal,
+or accept the value from the previous round.
+
+However, the discrete-time version has more limitations
+(fixed communication structure, limited number of iterations).
+
+Also, the continuous-time version works smoother & faster, 
+and is less resource-intensive since it all takes place in 1 page.
+"""
+
+
+class C(BaseConstants):
+    NAME_IN_URL = 'compound_besar_random_fixed'
+    PLAYERS_PER_GROUP = 2
+    NUM_ROUNDS = 20
+
+    # Keep the roles, profits, salary, officer cost
+    SALARY = 3125
+    OFFICER_COST = 10
+    SELLER_ROLE = 'Importir'
+    BUYER_ROLE = 'Petugas Pajak'
+
+    # Parameters for quantity and product price
+    FIXED_PRICE = 20
+    MEAN_QUANTITY = 200
+    SD_QUANTITY = 40
+
+    # Specific tariff (ST) for Mewah vs. Biasa
+    ST_MEWAH = 3
+    ST_BIASA = 2
+
+
+
+class Subsession(BaseSubsession):
+    pass
+
+
+def creating_session(subsession: Subsession):
+    # BUGFIX: in oTree 5 the grouping hook must be a MODULE-LEVEL function named
+    # `creating_session` taking the subsession as its argument. The previous app
+    # defined it as a method `Subsession.creating_session(self)`, which oTree 5
+    # never calls, so no re-grouping ran and partners stayed fixed across rounds.
+    #
+    # Re-shuffle into new random groups EVERY round (called once per round at
+    # session creation). `fixed_id_in_group=True` keeps each participant's
+    # id_in_group -- and therefore their role (Importir / Petugas Pajak) -- fixed,
+    # so only the partner changes, not the role. (Random re-matching; a repeat
+    # pairing by chance is possible and acceptable -- this is not perfect-stranger
+    # matching.)
+    subsession.group_randomly(fixed_id_in_group=True)
+
+class Group(BaseGroup):
+    deal_price = models.IntegerField()
+    is_finished = models.BooleanField(initial=False)
+    chance = models.IntegerField(initial=0)
+    chance2 = models.FloatField(initial=0)
+    # New field to store the random quantity (so it remains consistent if page is refreshed)
+    quantity = models.IntegerField(initial=0)
+    category = models.StringField()
+    bribe_chance = models.FloatField(initial=0)
+    audit = models.BooleanField()
+
+
+class Player(BasePlayer):
+    amount_proposed = models.IntegerField()
+    amount_accepted = models.IntegerField()
+    mewah_tariff = models.FloatField()
+    biasa_tariff = models.FloatField()
+    goods_value = models.FloatField()
+    pay = models.FloatField(initial=0)
+    tariff = models.FloatField(initial=0)
+    chance = models.IntegerField(initial=0)
+    bribe = models.IntegerField(blank=True, label="Iuran kepada auditor")
+    category = models.PositiveIntegerField(
+        choices=[[0, 'Barang Mewah'], [1, 'Barang Biasa']],
+        widget=widgets.RadioSelectHorizontal,
+        label="katagori barang"
+    )
+    payment = models.FloatField(initial=0)
+    penalty = models.FloatField(initial=0)
+    potential_penalty = models.FloatField(initial=0)
+    random_round = models.PositiveIntegerField()
+    rekening = models.StringField(label="Nomor Rekening")
+    tipe_pembayaran = models.StringField(widget=widgets.RadioSelect,
+                                label="Tipe Pembayaran",
+                                choices=["Gopay", "Ovo","Shopee","BNI","Mandiri","BCA","BRI"])
+    tipe_pembayaran_lain = models.StringField(
+        blank=True,
+        label="Jika lainnya, sebutkan:"
+    )
+    nomor_hp = models.StringField(label="Telepon")
+
+
+class Bargain(Page):
+    timeout_seconds = 180
+
+    @staticmethod
+    def vars_for_template(player: Player):
+        """Randomize quantity (once) and show possible tariffs for Barang Mewah & Biasa."""
+        group = player.group
+
+        # Randomize quantity only once per group (if not yet set).
+        if group.quantity == 0:
+            q = max(1, int(random.gauss(C.MEAN_QUANTITY, C.SD_QUANTITY)))
+            group.quantity = q
+
+        # Compute possible tariffs for demonstration (e.g. to show on the template).
+        player.goods_value = group.quantity * C.FIXED_PRICE
+
+        # Compound tariff for Mewah
+        player.mewah_tariff = (group.quantity*C.ST_MEWAH) + (group.quantity * C.FIXED_PRICE * 0.20)
+        # Compound tariff for Biasa
+        player.biasa_tariff = (group.quantity*C.ST_BIASA) + (group.quantity * C.FIXED_PRICE * 0.15)
+
+        return dict(
+            other_role=player.get_others_in_group()[0].role,
+            quantity=group.quantity,
+            mewah_tariff=int(player.mewah_tariff),
+            biasa_tariff=int(player.biasa_tariff),
+        )
+
+    @staticmethod
+    def js_vars(player: Player):
+        return dict(my_id=player.id_in_group)
+
+    @staticmethod
+    def live_method(player: Player, data):
+        group = player.group
+        [other] = player.get_others_in_group()
+
+        if 'amount' in data:
+            try:
+                amount = int(data['amount'])
+            except Exception:
+                print('Invalid message received', data)
+                return
+            if data['type'] == 'accept':
+                if amount == other.amount_proposed:
+                    player.amount_accepted = amount
+                    group.deal_price = amount
+                    group.is_finished = True
+                    return {0: dict(finished=True)}
+            if data['type'] == 'propose':
+                player.amount_proposed = amount
+            if data['type'] == 'reject':
+                if amount == other.amount_proposed:
+                    player.amount_accepted = 0
+                    group.deal_price = 0
+                    group.is_finished = True
+                    return {0: dict(finished=True)}
+
+        proposals = []
+        for p in [player, other]:
+            amount_proposed = p.field_maybe_none('amount_proposed')
+            if amount_proposed is not None:
+                proposals.append([p.id_in_group, amount_proposed])
+        return {0: dict(proposals=proposals)}
+
+    @staticmethod
+    def error_message(player: Player, values):
+        group = player.group
+        if not group.is_finished:
+            return "Game not finished yet"
+
+    @staticmethod
+    def is_displayed(player: Player):
+        """Skip this page if a deal has already been made"""
+        group = player.group
+        deal_price = group.field_maybe_none('deal_price')
+        return deal_price is None
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        """Use the new tariff scheme to compute player's payoff."""
+        group = player.group
+        if player.role == "Importir":
+            player.potential_penalty = 1.5 * player.mewah_tariff
+        else:
+            player.potential_penalty = 0.5 * C.SALARY
+        if timeout_happened:
+            player.amount_accepted = 0
+            player.amount_proposed = 0
+            group.deal_price = 0
+
+        # Compute tariff based on whether a 'deal_price' (bribe) was reached.
+        # If deal_price == 0 => treat as Barang Mewah
+        # If deal_price > 0 => treat as Barang Biasa
+        goods_value = group.quantity * C.FIXED_PRICE
+
+
+        if group.deal_price == 0:
+            # Barang Mewah
+            player.tariff = player.mewah_tariff
+            if player.role == "Importir":
+                player.pay = goods_value - player.tariff
+            else:
+                player.pay = C.SALARY
+        else:
+            # Barang Biasa
+            player.tariff = player.biasa_tariff
+            if player.role == "Importir":
+                # Importer pays the bribe plus the tariff
+                player.pay = goods_value - player.tariff - group.deal_price
+            else:
+                # Officer receives the bribe, minus cost
+                player.pay = C.SALARY + group.deal_price
+
+
+class Results(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.role == "Petugas Pajak"
+
+    form_model = 'player'
+    form_fields = ['bribe', 'category']
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        group = player.group
+        if player.category == 0:
+            group.category = "Barang Mewah"
+        else:
+            group.category = "Barang Biasa"
+        players = group.get_players()
+        bribe = player.field_maybe_none('bribe')
+        group.chance = random.randint(1,440)
+        if bribe is None:
+            player.bribe = 0
+        else:
+            if player.role == "Petugas Pajak":
+                player.pay = C.SALARY + group.deal_price - player.bribe
+            if player.bribe > 176:
+                bribe = 176
+            player.chance = bribe
+        group.bribe_chance = player.chance
+
+
+
+class ResultsWaitPage(WaitPage):
+    pass
+
+
+class Investigation(Page):
+    @staticmethod
+    def vars_for_template(player: Player):
+        group = player.group
+        if group.category == "Barang Biasa":
+            player.tariff = player.biasa_tariff
+            group.chance2 = 220 - group.bribe_chance
+            if group.chance < group.chance2:
+                group.audit = True
+                if player.role == "Importir":
+                    player.penalty = 1.5 * player.tariff
+                else:
+                    player.penalty = 0.5 * C.SALARY
+            else:
+                group.audit = False
+                player.penalty = 0
+        else:
+            player.tariff = player.mewah_tariff
+            player.penalty = 0
+            group.audit = False
+        player.payment = player.pay - player.penalty
+        if player.payment < 0:
+            player.payment = 0
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        participant = player.participant
+        # Store the current round's payment in participant vars
+        participant.vars[f'payment_round_{player.round_number}'] = player.payment
+
+        # If it's the last round, select a random round and set the payoff
+        if player.round_number == C.NUM_ROUNDS:
+            random_round = random.randint(1, C.NUM_ROUNDS)
+            participant.selected_round = random_round
+            player.random_round = random_round # This field is on the Player model, useful for display
+
+            # Retrieve the payment from the randomly selected round
+            pay_in_selected_round = participant.vars.get(f'payment_round_{random_round}', 0)
+            player.payoff = (pay_in_selected_round * 50) + 15000
+
+class MyWaitPage(WaitPage):
+    pass
+
+class Instructions(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.round_number == 1
+        
+
+
+class Results2(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.round_number == C.NUM_ROUNDS
+    
+    @staticmethod
+    def vars_for_template(player: Player):
+        participant = player.participant
+        selected_round = participant.selected_round
+        pay_in_selected_round = participant.vars.get(f'payment_round_{selected_round}', 0)
+
+        return dict(
+            selected_round=selected_round,
+            pay_in_selected_round=int(pay_in_selected_round),
+            final_payoff=int(player.payoff) # Access the payoff already calculated
+        )
+
+class payment(Page):
+    form_model = 'player'
+    form_fields = ['rekening', 'tipe_pembayaran', 'tipe_pembayaran_lain','nomor_hp']
+    @staticmethod
+    def is_displayed(player):
+        return player.round_number == C.NUM_ROUNDS
+
+
+page_sequence = [Instructions, ResultsWaitPage, Bargain, Results, ResultsWaitPage, Investigation, MyWaitPage, Results2,payment]

--- a/compound_besar_random_fixed/payment.html
+++ b/compound_besar_random_fixed/payment.html
@@ -1,0 +1,11 @@
+{{ block title }}
+    Survey
+{{ endblock }}
+{{ block content }}
+    <h3>Mohon isi kuesioner ini dengan sebenar-benarnya; untuk platform pembayaran online.
+        Eksperimenter tidak akan membagikan data yang Anda berikan kepada siapapun</h3><br>
+    <a href="https://docs.google.com/forms/d/1b6MVoxYYVEePoQiweADgW44A4m-h6x9ZHCFxzt3NOQ8/viewform?edit_requested=true&pli=1" target="_blank">
+    Klik di sini untuk mengisi kuesioner pembayaran
+</a><br><p></p>
+
+{{ endblock }}

--- a/compound_kecil_random_fixed/Bargain.html
+++ b/compound_kecil_random_fixed/Bargain.html
@@ -1,0 +1,185 @@
+{{ block title }}
+Pelaporan Pajak<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+
+<!-- Minimal CSS styling for a cleaner look -->
+<style>
+    .section-box {
+        margin-bottom: 1.5em;
+        padding: 1em;
+        background-color: #f9f9f9;
+        border: 1px solid #ddd;
+        border-radius: 5px;
+        line-height: 1.5;
+    }
+    .section-box h2 {
+        margin-top: 0;
+    }
+    .section-box ul {
+        margin-top: 0.5em;
+        margin-bottom: 0.5em;
+        padding-left: 1.5em;
+    }
+    .negotiation-table {
+        border-collapse: collapse;
+        width: 100%;
+        margin-top: 1em;
+    }
+    .negotiation-table th,
+    .negotiation-table td {
+        border: 1px solid #ccc;
+        padding: 0.5em;
+    }
+    .debug-section {
+        margin-top: 1em;
+        padding: 0.5em;
+        background-color: #fefefe;
+        border: 1px dashed #ccc;
+    }
+</style>
+
+{{ if player.role == "Importir" }}
+<div class="section-box">
+    <h2>Importir</h2>
+    <p>
+        Anda merupakan importir barang mewah yang berpotensi meraih keuntungan.
+        Saat ini, Anda mengimpor sejumlah <strong>{{ quantity }}</strong> unit.
+        Nilai barang = jumlah barang × harga (20 poin), sehingga nilai barang Anda adalah <strong>{{ player.goods_value }}</strong> poin.
+    </p>
+    <p>
+        Apabila barang dikategorikan sebagai <em>Barang Mewah</em>, tarif dihitung sebagai:
+        <br>
+        (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).
+        <br>
+        Nilai tarif barang mewah adalah <strong>{{ mewah_tariff }}</strong> poin.
+    </p>
+    <p>
+        Anda dapat bernegosiasi dengan petugas pajak untuk mengubah kategori menjadi <em>Barang Biasa</em>, sehingga tarif dihitung sebagai:
+        <br>
+        (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).
+        <br>
+        Nilai tarif barang biasa adalah <strong>{{ biasa_tariff }}</strong> poin.
+        Hasil kesepakatan Anda dengan petugas pajak tidak menjamin kategori akan berubah karena keputusan akhir ada di petugas pajak.
+    </p>
+    <p>
+        Jika terjadi audit (50:50) dan ditemukan ketidaksesuaian, maka denda sebesar 1.5 × nilai tarif akan dikenakan ke Anda.
+    </p>
+</div>
+{{ endif }}
+
+{{ if player.role == "Petugas Pajak" }}
+<div class="section-box">
+    <h2>Petugas Pajak</h2>
+    <p>
+        Anda merupakan petugas pajak impor dengan gaji <strong>{{C.SALARY}}</strong> poin.
+        Anda menentukan kategori barang (Mewah/Barang Biasa) dan menghitung tarif berikut:
+    </p>
+    <ul>
+        <li><em>Barang Mewah</em>: (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).</li>
+        <li><em>Barang Biasa</em>: (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).</li>
+    </ul>
+    <p>
+        Saat ini, jumlah barang mewah yang diimpor adalah sebanyak <strong>{{ quantity }}</strong> unit dengan nilai sebesar <strong>{{ player.goods_value }}</strong> poin.
+        Apabila barang dikategorikan sebagai <em>Barang Mewah</em>, maka nilai tarif = <strong>{{ mewah_tariff }}</strong> poin.
+        Apabila barang dikategorikan sebagai <em>Barang Biasa</em>, maka nilai tarif = <strong>{{ biasa_tariff }}</strong> poin.
+    </p>
+    <p>
+        Importir memiliki potensi keuntungan dan dapat menawarkan transfer kepada Anda agar barang dikategorikan sebagai Barang Biasa.
+        Namun, keputusan akhir ada di tangan Anda.
+        Jika terjadi audit (50:50) dan ditemukan ketidaksesuaian, maka denda sebesar 50% gaji akan dikenakan ke Anda.
+    </p>
+</div>
+{{ endif }}
+
+<p>
+    Silakan bernegosiasi dengan {{ other_role }} mengenai besaran transfer. Jika tidak tercapai kesepakatan,
+    tarif impor akan dikenakan penuh sesuai kategori awal, tanpa transfer.
+</p>
+
+<table class="negotiation-table">
+    <tr>
+        <th>Proposal Transfer Anda</th>
+        <td id="my-proposal">(none)</td>
+        <td>
+            <input type="number" id="my_offer">
+            <button type="button" onclick="sendOffer()" id="btn-offer">Ajukan Transfer</button>
+        </td>
+    </tr>
+
+    <tr>
+        <th>Proposal Transfer {{ other_role }}</th>
+        <td id="other-proposal">(none)</td>
+{{ if player.role == "Petugas Pajak" }}
+        <td>
+            <button type="button" id="btn-accept" onclick="sendAccept(this)" style="display: none">Terima</button>
+        </td>
+        <td>
+            <button type="button" id="btn-reject" onclick="sendReject(this)" style="display: none">Tolak</button>
+        </td>
+    </tr>
+{{ endif }}
+</table>
+
+<h4>Chat</h4>
+{{ chat nickname=player.role }}
+
+<!-- No changes to JavaScript below -->
+<script>
+    let my_offer = document.getElementById('my_offer');
+    let btnAccept = document.getElementById('btn-accept');
+    let btnReject = document.getElementById('btn-reject');
+    let msgOtherProposal = document.getElementById('other-proposal');
+    let msgMyProposal = document.getElementById('my-proposal');
+
+    let otherProposal;
+
+    my_offer.addEventListener("keydown", function (event) {
+        if (event.key === "Enter") {
+            sendOffer();
+        }
+    });
+
+    function sendOffer() {
+        liveSend({'type': 'propose', 'amount': my_offer.value})
+        my_offer.value = '';
+    }
+
+    function sendAccept() {
+        liveSend({'type': 'accept', 'amount': otherProposal})
+    }
+
+    function sendReject() {
+        liveSend({'type': 'reject', 'amount': otherProposal})
+    }
+
+    function cu(amount) {
+        return `${amount} poin`;
+    }
+
+    function liveRecv(data) {
+        if ('proposals' in data) {
+            for (let [id_in_group, proposal] of data.proposals) {
+                if (id_in_group === js_vars.my_id) {
+                    msgMyProposal.innerHTML = cu(proposal);
+                } else {
+                    msgOtherProposal.innerHTML = cu(proposal);
+                    otherProposal = proposal;
+                    btnAccept.style.display = 'block';
+                    btnReject.style.display = 'block';
+                }
+            }
+        }
+        if ('finished' in data) {
+            document.getElementById('form').submit();
+        }
+    }
+
+    window.addEventListener('DOMContentLoaded', (event) => {
+        liveSend({});
+    });
+</script>
+
+{{ endblock }}

--- a/compound_kecil_random_fixed/Instructions.html
+++ b/compound_kecil_random_fixed/Instructions.html
@@ -1,0 +1,11 @@
+{{ block title }}
+    Sesi Dimulai
+{{ endblock }}
+{{ block content }}
+    Anda akan memasuki sesi yang sebenarnya, keputusan Anda akan berdampak kepada pendapatan Anda di akhir sesi.
+        Anda akan terhubung dengan petugas atau importir yang sama selama sesi eksperimen. Selamat menjalankan eksperimen.
+
+{{ next_button }}
+
+
+{{ endblock }}

--- a/compound_kecil_random_fixed/Investigation.html
+++ b/compound_kecil_random_fixed/Investigation.html
@@ -1,0 +1,44 @@
+{{ block title }}
+   Hasil<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+
+{% if group.audit == True and group.category == "Barang Biasa" %}
+<p>
+    Hasil audit menemukan ketidaksesuaian pada pelaporan kategori.
+    Denda sebesar <strong>{{ player.penalty }} poin</strong> diberlakukan, <br>
+    {{ if player.role == "Importir" }}
+    Pendapatan akhir Anda adalah = Nilai Barang ({{ player.goods_value }}) - Biaya tarif ({{ player.tariff }}) - Kesepakatan transfer ({{ group.deal_price }}) - Denda ({{ player.penalty }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+    {{ if player.role == "Petugas Pajak" }}
+    Pendapatan akhir Anda adalah Gaji ({{C.SALARY}}) + Kesepakatan transfer ({{ group.deal_price }}) - Transfer ke auditor ({{player.bribe}}) - Denda ({{ player.penalty }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+</p>
+{% endif %}
+
+{% if group.audit == False or group.category == "Barang Mewah" %}
+<p>
+    Tidak ditemukan ketidaksesuaian dalam laporan Anda.
+    Total Tarif yang berlaku adalah = {{ player.tariff }} poin.<br>
+    {{ if player.role == "Importir" }}
+    Pendapatan akhir Anda adalah Nilai Barang ({{ player.goods_value }}) - Biaya tarif ({{ player.tariff }}) - Kesepakatan transfer ({{ group.deal_price }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+    {{ if player.role == "Petugas Pajak" }}
+    Pendapatan akhir Anda adalah Gaji ({{C.SALARY}}) + Kesepakatan transfer ({{ group.deal_price }}) - Transfer ke auditor ({{player.bribe}}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+</p>
+{% endif %}
+
+<hr>
+<p>
+    <strong>Jumlah Barang Diimpor:</strong> {{ group.quantity }}<br>
+    <strong>Kategori Barang Impor Dari Petugas: </strong> {{ group.category }}<br>
+    <strong>Total Tarif yang berlaku adalah = {{ player.tariff }}</strong><br>
+    <strong>Denda Saat Ini:</strong> {{ player.penalty }} poin
+</p>
+
+{{ next_button }}
+
+{{ endblock }}

--- a/compound_kecil_random_fixed/Results.html
+++ b/compound_kecil_random_fixed/Results.html
@@ -1,0 +1,42 @@
+{{ block title }}
+    Pengambilan Keputusan<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+<p>
+    Kategori apa yang akan Anda berikan kepada barang impor tersebut?
+    {{ formfield 'category' }}
+</p>
+
+Nilai Barang = {{ player.goods_value }} poin<br>
+Tarif barang mewah = (jumlah barang × 3) +(jumlah barang × harga barang (20 poin) × 20%) = {{ player.mewah_tariff }} poin<br>
+Tarif barang biasa = (jumlah barang × 2) +(jumlah barang × harga barang (20 poin) × 15%) = {{ player.biasa_tariff }} poin<br>
+
+{{ if group.deal_price == 0 }}
+<p>
+    Tidak ada negosiasi, sehingga Anda tidak menerima transfer dari importir.
+</p>
+{{ next_button }}
+{{ endif }}
+<br><br>
+
+{{ if group.deal_price > 0 }}
+<p>
+    Anda menyepakati untuk menerima transfer sebesar <strong>{{ group.deal_price }} poin</strong>.
+</p>
+<p>
+    Kegiatan ini memiliki kemungkinan audit 50:50. Jika audit menemukan ketidaksesuaian,
+    denda sebesar <strong>{{ player.potential_penalty }} poin</strong> akan dikenakan pada pendapatan importir dan petugas pajak.
+</p>
+<p>
+    Anda juga berkesempatan memberikan transfer kepada auditor untuk mengurangi risiko audit. Setiap 1 poin yang dikirim petugas ke auditor akan menurunkan peluang audit sebesar 1% dan kemungkinan
+              terendah Anda akan terkena audit adalah 10%.
+</p>
+{{ formfield 'bribe' }}
+{{ next_button }}
+{{ endif }}
+
+<hr>
+
+{{ endblock }}

--- a/compound_kecil_random_fixed/Results2.html
+++ b/compound_kecil_random_fixed/Results2.html
@@ -1,0 +1,12 @@
+{{ block title }}
+    Anda telah menyelesaikan ronde terakhir pada sesi ini
+{{ endblock }}
+{{ block content }}
+Setelah dilakukan pengacakan, terpilih ronde {{selected_round}} sebagai ronde pembyaran Anda pada sesi ini. <br>
+Hasil Anda pada ronde tersebut adalah {{pay_in_selected_round}} poin. Poin ini dikalikan Rp50 rupiah untuk pembayaran eksperimen yaitu {{pay_in_selected_round}} x 50 + uang kehadiran Rp15000 = {{final_payoff}} <br><br>
+<button>
+    Lanjut
+</button><p></p>
+
+{{ endblock }}
+

--- a/compound_kecil_random_fixed/__init__.py
+++ b/compound_kecil_random_fixed/__init__.py
@@ -1,0 +1,322 @@
+from otree.api import *
+import random
+import math
+
+doc = """
+For oTree beginners, it would be simpler to implement this as a discrete-time game 
+by using multiple rounds, e.g. 10 rounds, where in each round both players can make a new proposal,
+or accept the value from the previous round.
+
+However, the discrete-time version has more limitations
+(fixed communication structure, limited number of iterations).
+
+Also, the continuous-time version works smoother & faster, 
+and is less resource-intensive since it all takes place in 1 page.
+"""
+
+
+class C(BaseConstants):
+    NAME_IN_URL = 'compound_kecil_random_fixed'
+    PLAYERS_PER_GROUP = 2
+    NUM_ROUNDS = 20
+
+    # Keep the roles, profits, salary, officer cost
+    SALARY = 500
+    SELLER_ROLE = 'Importir'
+    BUYER_ROLE = 'Petugas Pajak'
+
+    # Parameters for quantity and product price
+    FIXED_PRICE = 20
+    MEAN_QUANTITY = 32
+    SD_QUANTITY = 6.4
+
+    # Specific tariff (ST) for Mewah vs. Biasa
+    ST_MEWAH = 3
+    ST_BIASA = 2
+
+
+
+class Subsession(BaseSubsession):
+    pass
+
+
+def creating_session(subsession: Subsession):
+    # BUGFIX: in oTree 5 the grouping hook must be a MODULE-LEVEL function named
+    # `creating_session` taking the subsession as its argument. The previous app
+    # defined it as a method `Subsession.creating_session(self)`, which oTree 5
+    # never calls, so no re-grouping ran and partners stayed fixed across rounds.
+    #
+    # Re-shuffle into new random groups EVERY round (called once per round at
+    # session creation). `fixed_id_in_group=True` keeps each participant's
+    # id_in_group -- and therefore their role (Importir / Petugas Pajak) -- fixed,
+    # so only the partner changes, not the role. (Random re-matching; a repeat
+    # pairing by chance is possible and acceptable -- this is not perfect-stranger
+    # matching.)
+    subsession.group_randomly(fixed_id_in_group=True)
+
+class Group(BaseGroup):
+    deal_price = models.IntegerField()
+    is_finished = models.BooleanField(initial=False)
+    chance = models.IntegerField(initial=0)
+    chance2 = models.FloatField(initial=0)
+    # New field to store the random quantity (so it remains consistent if page is refreshed)
+    quantity = models.IntegerField(initial=0)
+    category = models.StringField()
+    bribe_chance = models.FloatField(initial=0)
+    audit = models.BooleanField()
+
+
+class Player(BasePlayer):
+    amount_proposed = models.IntegerField()
+    amount_accepted = models.IntegerField()
+    mewah_tariff = models.FloatField()
+    biasa_tariff = models.FloatField()
+    goods_value = models.FloatField()
+    pay = models.FloatField(initial=0)
+    tariff = models.FloatField(initial=0)
+    chance = models.IntegerField(initial=0)
+    bribe = models.IntegerField(blank=True, label="Iuran kepada auditor")
+    category = models.PositiveIntegerField(
+        choices=[[0, 'Barang Mewah'], [1, 'Barang Biasa']],
+        widget=widgets.RadioSelectHorizontal,
+        label="katagori barang"
+    )
+    payment = models.FloatField(initial=0)
+    penalty = models.FloatField(initial=0)
+    potential_penalty = models.FloatField(initial=0)
+    random_round = models.PositiveIntegerField()
+    rekening = models.StringField(label="Nomor Rekening")
+    tipe_pembayaran = models.StringField(widget=widgets.RadioSelect,
+                                label="Tipe Pembayaran",
+                                choices=["Gopay", "Ovo","Shopee","BNI","Mandiri","BCA","BRI"])
+    tipe_pembayaran_lain = models.StringField(
+        blank=True,
+        label="Jika lainnya, sebutkan:"
+    )
+    nomor_hp = models.StringField(label="Telepon")
+
+
+class Bargain(Page):
+    timeout_seconds = 180
+
+    @staticmethod
+    def vars_for_template(player: Player):
+        """Randomize quantity (once) and show possible tariffs for Barang Mewah & Biasa."""
+        group = player.group
+
+        # Randomize quantity only once per group (if not yet set).
+        if group.quantity == 0:
+            q = max(1, int(random.gauss(C.MEAN_QUANTITY, C.SD_QUANTITY)))
+            group.quantity = q
+
+        # Compute possible tariffs for demonstration (e.g. to show on the template).
+        player.goods_value = group.quantity * C.FIXED_PRICE
+
+        # Compound tariff for Mewah
+        player.mewah_tariff = (group.quantity*C.ST_MEWAH) + (group.quantity * C.FIXED_PRICE * 0.20)
+        # Compound tariff for Biasa
+        player.biasa_tariff = (group.quantity*C.ST_BIASA) + (group.quantity * C.FIXED_PRICE * 0.15)
+
+        return dict(
+            other_role=player.get_others_in_group()[0].role,
+            quantity=group.quantity,
+            mewah_tariff=int(player.mewah_tariff),
+            biasa_tariff=int(player.biasa_tariff),
+        )
+
+    @staticmethod
+    def js_vars(player: Player):
+        return dict(my_id=player.id_in_group)
+
+    @staticmethod
+    def live_method(player: Player, data):
+        group = player.group
+        [other] = player.get_others_in_group()
+
+        if 'amount' in data:
+            try:
+                amount = int(data['amount'])
+            except Exception:
+                print('Invalid message received', data)
+                return
+            if data['type'] == 'accept':
+                if amount == other.amount_proposed:
+                    player.amount_accepted = amount
+                    group.deal_price = amount
+                    group.is_finished = True
+                    return {0: dict(finished=True)}
+            if data['type'] == 'propose':
+                player.amount_proposed = amount
+            if data['type'] == 'reject':
+                if amount == other.amount_proposed:
+                    player.amount_accepted = 0
+                    group.deal_price = 0
+                    group.is_finished = True
+                    return {0: dict(finished=True)}
+
+        proposals = []
+        for p in [player, other]:
+            amount_proposed = p.field_maybe_none('amount_proposed')
+            if amount_proposed is not None:
+                proposals.append([p.id_in_group, amount_proposed])
+        return {0: dict(proposals=proposals)}
+
+    @staticmethod
+    def error_message(player: Player, values):
+        group = player.group
+        if not group.is_finished:
+            return "Game not finished yet"
+
+    @staticmethod
+    def is_displayed(player: Player):
+        """Skip this page if a deal has already been made"""
+        group = player.group
+        deal_price = group.field_maybe_none('deal_price')
+        return deal_price is None
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        """Use the new tariff scheme to compute player's payoff."""
+        group = player.group
+        if player.role == "Importir":
+            player.potential_penalty = 1.5 * player.mewah_tariff
+        else:
+            player.potential_penalty = 0.5 * C.SALARY
+        if timeout_happened:
+            player.amount_accepted = 0
+            player.amount_proposed = 0
+            group.deal_price = 0
+
+        # Compute tariff based on whether a 'deal_price' (bribe) was reached.
+        # If deal_price == 0 => treat as Barang Mewah
+        # If deal_price > 0 => treat as Barang Biasa
+        goods_value = group.quantity * C.FIXED_PRICE
+
+
+        if group.deal_price == 0:
+            # Barang Mewah
+            player.tariff = player.mewah_tariff
+            if player.role == "Importir":
+                player.pay = goods_value - player.tariff
+            else:
+                player.pay = C.SALARY
+        else:
+            # Barang Biasa
+            player.tariff = player.biasa_tariff
+            if player.role == "Importir":
+                # Importer pays the bribe plus the tariff
+                player.pay = goods_value - player.tariff - group.deal_price
+            else:
+                # Officer receives the bribe, minus cost
+                player.pay = C.SALARY + group.deal_price
+
+
+class Results(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.role == "Petugas Pajak"
+
+    form_model = 'player'
+    form_fields = ['bribe', 'category']
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        group = player.group
+        if player.category == 0:
+            group.category = "Barang Mewah"
+        else:
+            group.category = "Barang Biasa"
+        players = group.get_players()
+        bribe = player.field_maybe_none('bribe')
+        group.chance = random.randint(1,100)
+        if bribe is None:
+            player.bribe = 0
+        else:
+            if player.role == "Petugas Pajak":
+                player.pay = C.SALARY + group.deal_price - player.bribe
+            if player.bribe > 40:
+                bribe = 40
+            player.chance = bribe
+        group.bribe_chance = player.chance
+
+
+
+class ResultsWaitPage(WaitPage):
+    pass
+
+
+class Investigation(Page):
+    @staticmethod
+    def vars_for_template(player: Player):
+        group = player.group
+        if group.category == "Barang Biasa":
+            player.tariff = player.biasa_tariff
+            group.chance2 = 50 - group.bribe_chance
+            if group.chance < group.chance2:
+                group.audit = True
+                if player.role == "Importir":
+                    player.penalty = 1.5 * player.tariff
+                else:
+                    player.penalty = 0.5 * C.SALARY
+            else:
+                group.audit = False
+                player.penalty = 0
+        else:
+            player.tariff = player.mewah_tariff
+            player.penalty = 0
+            group.audit = False
+        player.payment = player.pay - player.penalty
+        if player.payment < 0:
+            player.payment = 0
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        participant = player.participant
+        # Store the current round's payment in participant vars
+        participant.vars[f'payment_round_{player.round_number}'] = player.payment
+
+        # If it's the last round, select a random round and set the payoff
+        if player.round_number == C.NUM_ROUNDS:
+            random_round = random.randint(1, C.NUM_ROUNDS)
+            participant.selected_round = random_round
+            player.random_round = random_round # This field is on the Player model, useful for display
+
+            # Retrieve the payment from the randomly selected round
+            pay_in_selected_round = participant.vars.get(f'payment_round_{random_round}', 0)
+            player.payoff = (pay_in_selected_round * 50) + 15000
+
+class MyWaitPage(WaitPage):
+    pass
+
+class Instructions(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.round_number == 1
+
+
+class Results2(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.round_number == C.NUM_ROUNDS
+    
+    @staticmethod
+    def vars_for_template(player: Player):
+        participant = player.participant
+        selected_round = participant.selected_round
+        pay_in_selected_round = participant.vars.get(f'payment_round_{selected_round}', 0)
+
+        return dict(
+            selected_round=selected_round,
+            pay_in_selected_round=int(pay_in_selected_round),
+            final_payoff=int(player.payoff) # Access the payoff already calculated
+        )
+
+class payment(Page):
+    form_model = 'player'
+    form_fields = ['rekening', 'tipe_pembayaran', 'tipe_pembayaran_lain','nomor_hp']
+    @staticmethod
+    def is_displayed(player):
+        return player.round_number == C.NUM_ROUNDS
+
+
+page_sequence = [Instructions, ResultsWaitPage, Bargain, Results, ResultsWaitPage, Investigation, MyWaitPage, Results2,payment]

--- a/compound_kecil_random_fixed/payment.html
+++ b/compound_kecil_random_fixed/payment.html
@@ -1,0 +1,11 @@
+{{ block title }}
+    Survey
+{{ endblock }}
+{{ block content }}
+    <h3>Mohon isi kuesioner ini dengan sebenar-benarnya; untuk platform pembayaran online.
+        Eksperimenter tidak akan membagikan data yang Anda berikan kepada siapapun</h3><br>
+    <a href="https://docs.google.com/forms/d/1b6MVoxYYVEePoQiweADgW44A4m-h6x9ZHCFxzt3NOQ8/viewform?edit_requested=true&pli=1" target="_blank">
+    Klik di sini untuk mengisi kuesioner pembayaran
+</a><br><p></p>
+
+{{ endblock }}

--- a/compound_practice_random_besar_fixed/Bargain.html
+++ b/compound_practice_random_besar_fixed/Bargain.html
@@ -1,0 +1,185 @@
+{{ block title }}
+Pelaporan Pajak (SESI LATIHAN)<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+
+<!-- Minimal CSS styling for a cleaner look -->
+<style>
+    .section-box {
+        margin-bottom: 1.5em;
+        padding: 1em;
+        background-color: #f9f9f9;
+        border: 1px solid #ddd;
+        border-radius: 5px;
+        line-height: 1.5;
+    }
+    .section-box h2 {
+        margin-top: 0;
+    }
+    .section-box ul {
+        margin-top: 0.5em;
+        margin-bottom: 0.5em;
+        padding-left: 1.5em;
+    }
+    .negotiation-table {
+        border-collapse: collapse;
+        width: 100%;
+        margin-top: 1em;
+    }
+    .negotiation-table th,
+    .negotiation-table td {
+        border: 1px solid #ccc;
+        padding: 0.5em;
+    }
+    .debug-section {
+        margin-top: 1em;
+        padding: 0.5em;
+        background-color: #fefefe;
+        border: 1px dashed #ccc;
+    }
+</style>
+
+{{ if player.role == "Importir" }}
+<div class="section-box">
+    <h2>Importir</h2>
+    <p>
+        Anda merupakan importir barang mewah yang berpotensi meraih keuntungan.
+        Saat ini, Anda mengimpor sejumlah <strong>{{ quantity }}</strong> unit.
+        Nilai barang = jumlah barang × harga (20 poin), sehingga nilai barang Anda adalah <strong>{{ player.goods_value }}</strong> poin.
+    </p>
+    <p>
+        Apabila barang dikategorikan sebagai <em>Barang Mewah</em>, tarif dihitung sebagai:
+        <br>
+        (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).
+        <br>
+        Nilai tarif barang mewah adalah <strong>{{ mewah_tariff }}</strong> poin.
+    </p>
+    <p>
+        Anda dapat bernegosiasi dengan petugas pajak untuk mengubah kategori menjadi <em>Barang Biasa</em>, sehingga tarif dihitung sebagai:
+        <br>
+        (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).
+        <br>
+        Nilai tarif barang biasa adalah <strong>{{ biasa_tariff }}</strong> poin.
+        Hasil kesepakatan Anda dengan petugas pajak tidak menjamin kategori akan berubah karena keputusan akhir ada di petugas pajak.
+    </p>
+    <p>
+        Jika terjadi audit (50:50) dan ditemukan ketidaksesuaian, maka denda sebesar 1.5 × nilai tarif akan dikenakan ke Anda.
+    </p>
+</div>
+{{ endif }}
+
+{{ if player.role == "Petugas Pajak" }}
+<div class="section-box">
+    <h2>Petugas Pajak</h2>
+    <p>
+        Anda merupakan petugas pajak impor dengan gaji <strong>{{C.SALARY}}</strong> poin.
+        Anda menentukan kategori barang (Mewah/Barang Biasa) dan menghitung tarif berikut:
+    </p>
+    <ul>
+        <li><em>Barang Mewah</em>: (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).</li>
+        <li><em>Barang Biasa</em>: (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).</li>
+    </ul>
+    <p>
+        Saat ini, jumlah barang mewah yang diimpor adalah sebanyak <strong>{{ quantity }}</strong> unit dengan nilai sebesar <strong>{{ player.goods_value }}</strong> poin.
+        Apabila barang dikategorikan sebagai <em>Barang Mewah</em>, maka nilai tarif = <strong>{{ mewah_tariff }}</strong> poin.
+        Apabila barang dikategorikan sebagai <em>Barang Biasa</em>, maka nilai tarif = <strong>{{ biasa_tariff }}</strong> poin.
+    </p>
+    <p>
+        Importir memiliki potensi keuntungan dan dapat menawarkan transfer kepada Anda agar barang dikategorikan sebagai Barang Biasa.
+        Namun, keputusan akhir ada di tangan Anda.
+        Jika terjadi audit (50:50) dan ditemukan ketidaksesuaian, maka denda sebesar 50% gaji akan dikenakan ke Anda.
+    </p>
+</div>
+{{ endif }}
+
+<p>
+    Silakan bernegosiasi dengan {{ other_role }} mengenai besaran transfer. Jika tidak tercapai kesepakatan,
+    tarif impor akan dikenakan penuh sesuai kategori awal, tanpa transfer.
+</p>
+
+<table class="negotiation-table">
+    <tr>
+        <th>Proposal Transfer Anda</th>
+        <td id="my-proposal">(none)</td>
+        <td>
+            <input type="number" id="my_offer">
+            <button type="button" onclick="sendOffer()" id="btn-offer">Ajukan Transfer</button>
+        </td>
+    </tr>
+
+    <tr>
+        <th>Proposal Transfer {{ other_role }}</th>
+        <td id="other-proposal">(none)</td>
+{{ if player.role == "Petugas Pajak" }}
+        <td>
+            <button type="button" id="btn-accept" onclick="sendAccept(this)" style="display: none">Terima</button>
+        </td>
+        <td>
+            <button type="button" id="btn-reject" onclick="sendReject(this)" style="display: none">Tolak</button>
+        </td>
+    </tr>
+{{ endif }}
+</table>
+
+<h4>Chat</h4>
+{{ chat nickname=player.role }}
+
+<!-- No changes to JavaScript below -->
+<script>
+    let my_offer = document.getElementById('my_offer');
+    let btnAccept = document.getElementById('btn-accept');
+    let btnReject = document.getElementById('btn-reject');
+    let msgOtherProposal = document.getElementById('other-proposal');
+    let msgMyProposal = document.getElementById('my-proposal');
+
+    let otherProposal;
+
+    my_offer.addEventListener("keydown", function (event) {
+        if (event.key === "Enter") {
+            sendOffer();
+        }
+    });
+
+    function sendOffer() {
+        liveSend({'type': 'propose', 'amount': my_offer.value})
+        my_offer.value = '';
+    }
+
+    function sendAccept() {
+        liveSend({'type': 'accept', 'amount': otherProposal})
+    }
+
+    function sendReject() {
+        liveSend({'type': 'reject', 'amount': otherProposal})
+    }
+
+    function cu(amount) {
+        return `${amount} poin`;
+    }
+
+    function liveRecv(data) {
+        if ('proposals' in data) {
+            for (let [id_in_group, proposal] of data.proposals) {
+                if (id_in_group === js_vars.my_id) {
+                    msgMyProposal.innerHTML = cu(proposal);
+                } else {
+                    msgOtherProposal.innerHTML = cu(proposal);
+                    otherProposal = proposal;
+                    btnAccept.style.display = 'block';
+                    btnReject.style.display = 'block';
+                }
+            }
+        }
+        if ('finished' in data) {
+            document.getElementById('form').submit();
+        }
+    }
+
+    window.addEventListener('DOMContentLoaded', (event) => {
+        liveSend({});
+    });
+</script>
+
+{{ endblock }}

--- a/compound_practice_random_besar_fixed/Instructions.html
+++ b/compound_practice_random_besar_fixed/Instructions.html
@@ -1,0 +1,378 @@
+{% extends "global/Page.html" %}
+{% block content %}
+
+<form id="instructionsForm" method="post" style="margin: 0; padding: 0;">
+
+  <!-- PAGE 1: General Instructions -->
+  <div id="page1" style="display: block;">
+    <div style="
+      max-width: 800px;
+      margin: 40px auto;
+      padding: 20px;
+      border: 2px solid #000;
+      background-color: #fff;
+      line-height: 1.5;
+      text-align: justify;
+    ">
+      <h2 style="text-align: center; margin-top: 0;">INSTRUKSI</h2>
+
+      <p>
+        Selamat datang dan terima kasih telah bersedia untuk mengikuti eksperimen ini.
+        Mohon baca instruksi ini dengan seksama agar Anda memahami apa yang harus Anda lakukan di dalam eksperimen ini.
+        Eksperimen ini memberikan Anda kesempatan untuk memperoleh uang tunai yang akan dibayarkan segera setelah Anda menyelesaikan rangkaian eksperimen ini.
+        Besaran uang yang akan Anda peroleh bergantung pada apa yang Anda dan rekan Anda lakukan di dalam eksperimen ini.
+        Oleh karenanya, mohon untuk serius dalam menyelesaikannya sesuai dengan preferensi Anda.
+      </p>
+
+      <p>
+        Eksperimen ini bertujuan untuk memahami perilaku dan interaksi yang terjadi di dalam sebuah pelaporan dan pengecekan barang impor.
+        Anda akan ditempatkan secara acak apakah menjadi seorang importir barang atau petugas yang melakukan cek atas barang impor sepanjang eksperimen ini.
+        Jumlah importir dan petugas akan sama di satu sesi eksperimen. Anda akan menghadapi 20 ronde dengan tipikal yang sama sesuai peran Anda masing-masing:
+        seorang importir atau petugas. Peserta akan berinteraksi satu sama lain dalam 3 menit per rondenya.
+        Anda bisa berkomunikasi dengan lawan main di setiap ronde melalui kolom chat yang tersedia. Seluruh peserta akan menyelesaikan eksperimen ini secara bersamaan.
+        Selain itu, Anda juga akan diminta untuk mengisi kuesioner singkat setelah Anda menyelesaikan eksperimen ini.
+      </p>
+
+      <p>
+        Eksperimen ini telah mendapatkan persetujuan dari Komisi Etik Direktorat Penelitian UGM.
+        Lembar persetujuan terinformasi telah dikirim bersamaan dengan email undangan dan telah Anda setujui. Anda dapat melihat kembali lembar tersebut di <a href="
+        https://drive.google.com/file/d/1eS9WdjCHcOSkZf494_D67Rge-8DPnUFr/view?usp=sharing" target="_blank">https://drive.google.com/file/d/1eS9WdjCHcOSkZf494_D67Rge-8DPnUFr/view?usp=sharing</a>
+      </p>
+
+      <p>
+        Silakan klik tombol <strong>LANJUT</strong> di bawah ini untuk mendapatkan acakan peran di dalam eksperimen ini.
+      </p>
+
+      <div style="text-align: center;">
+        <button type="button" onclick="showPage(2)">LANJUT</button>
+      </div>
+
+      <p style="text-align: center; margin-top: 30px;">
+        <em>Tim Peneliti</em>
+      </p>
+    </div>
+  </div>
+
+
+  <!-- PAGE 2: Role-Specific Instructions with lined tables -->
+  <div id="page2" style="display: none;">
+    {% if player.role == "Importir" %}
+      <!-- IMPORTIR -->
+      <div style="
+        max-width: 800px;
+        margin: 40px auto;
+        padding: 20px;
+        border: 2px solid #000;
+        background-color: #fff;
+        line-height: 1.5;
+        text-align: justify;
+      ">
+
+        <h2 style="margin-top: 0;">
+          **** Instruksi untuk Importir ****
+        </h2>
+        <h3>ANDA MENDAPATKAN PERAN SEBAGAI IMPORTIR BARANG</h3>
+
+        <h4>Eksperimen</h4>
+        <p>
+          Sebagai seorang importir, Anda melakukan impor barang mewah dengan nilai tertentu di mana barang impor tersebut akan dikenai tarif impor barang mewah.
+          Besaran tarif impor barang mewah bergantung dari jumlah dan harga barang yang Anda impor.
+          Di setiap ronde, Anda harus melaporkan nilai dari barang yang Anda impor kepada petugas untuk dihitung nilai tarif impornya yang akan menjadi tanggungan Anda.
+          Anda dapat berkomunikasi kepada petugas melalui kolom chat.
+          Akan terdapat auditor yang secara acak mengecek laporan pajak Anda.
+          Berikut adalah penjelasan umum eksperimen untuk Anda sebagai importir barang:
+        </p>
+
+        <table style="width: 100%; border-collapse: collapse; border: 1px solid black;">
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top; width: 30%;">
+              Kategori Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Terdapat dua kategori barang impor dalam eksperimen ini: Barang Mewah dan Barang Biasa.
+              Kedua barang berbeda dalam pengenaan tarif pajaknya.
+              Namun, Anda hanya akan mengimpor barang mewah di dalam eksperimen ini.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Harga dan Kuantitas Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Kuantitas barang yang Anda impor (<em>Q</em>) diambil secara acak dari distribusi normal dengan rata-rata {{C.MEAN_QUANTITY}} dan deviasi standar {{C.SD_QUANTITY}}.
+              Harga barang mewah yang Anda impor (<em>P</em>) akan selalu tetap untuk seluruh ronde yaitu {{C.FIXED_PRICE}} poin.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Nilai Tarif Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Eksperimen ini menggunakan tarif compound dengan penghitungan
+              <code>T = (Q * s) + (Q * P * t)</code>, di mana s adalah tarif spesifik yang dikenakan per unit barang
+              diimpor dan t adalah tarif ad valorem dalam bentuk persen dari total nilai impor.
+              Pengenaan tarif impor T didasarkan atas klasifikasi barang impor sebagai berikut:
+
+              <ul>
+                <li><em>Barang Mewah</em>: (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).</li>
+                <li><em>Barang Biasa</em>: (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).</li>
+              </ul>
+              Dalam hal ini, barang impor akan dikenakan pajak yang lebih murah ketika dikategorikan sebagai barang biasa daripada barang mewah.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Interaksi dengan Petugas Pajak
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan dihubungkan dengan <strong> satu petugas pajak yang berbeda </strong> sepanjang eksperimen ini yang tugasnya adalah memastikan pelaporan barang yang Anda impor.
+              Anda dan petugas pajak akan berada di halaman yang sama pada saat pelaporan barang impor Anda.
+              Petugas pajak yang akan membersamai Anda ditentukan secara acak sebelum ronde pertama dimulai dan bersifat anonim.
+              Anda dapat berkomunikasi kepada petugas melalui kolom chat dan Anda dapat mengirimkan transfer kepada petugas pajak untuk mengubah kategori barang impor Anda.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Proses Audit atas Laporan Petugas Pajak
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Petugas pajak mengirimkan laporan pajak Anda ke otoritas pajak. Petugas pajak bisa saja melaporkan jenis
+              barang yang berbeda dari yang didiskusikan sebelumnya. Auditor (komputer) akan mengumpulkan seluruh laporan
+              pajak yang dikirimkan oleh petugas pajak untuk diaudit. Laporan pajak Anda memiliki kemungkinan untuk menjadi
+              sampel audit sebesar 50%. Jika hasil audit menunjukkan Anda tidak melaporkan sesuai dengan nilai impor sesungguhnya,
+              maka Anda akan menerima denda. Petugas dapat menurunkan peluang laporan pajak Anda diaudit dengan mengirimkan transfer
+              ke Auditor. Setiap 1 poin yang dikirim petugas ke auditor akan menurunkan peluang audit sebesar 0.2% dan kemungkinan
+              terendah Anda akan terkena audit adalah 10%.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Denda atas Laporan yang Tidak Sesuai
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Jika hasil audit menunjukkan laporan yang tidak sesuai, maka denda yang Anda terima adalah sebesar 150% dari nilai tarif yang Anda bayarkan.
+              Denda ini di luar nilai tarif yang telah Anda bayarkan berdasarkan laporan yang Anda berikan.
+              Transfer Anda kepada petugas dalam proses negosiasi akan hangus dan tidak dikembalikan kepada Anda.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Payoff di Setiap Ronde
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Basis payoff Anda adalah nilai barang impor yang Anda lakukan dan proses yang terjadi setelahnya.
+              Payoff dari setiap ronde akan diinformasikan setelah suatu ronde berakhir dengan penghitungan sebagai berikut:
+              <br><em>Nilai barang yang diimpor – pajak impor (berdasarkan laporan Anda) – nilai transaksi negosiasi (jika ada) – denda (jika ada)</em>.
+              <br>Jika payoff terhitung Anda adalah negatif, maka payoff Anda di ronde tersebut adalah nol.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Catatan Penting
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda dan petugas akan berada pada halaman yang sama di setiap ronde pada saat proses pelaporan.
+              Anda (tidak) akan diinformasikan lawan main (petugas pajak) di setiap ronde.
+              Informasi tersebut berupa kode partisipan masing-masing partisipan mengacu pada nomor meja.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Durasi Eksperimen
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Kami mengestimasi penyelesaian rangkaian eksperimen ini selama lebih-kurang 90 menit.
+              Kami harap Anda menyelesaikan eksperimen ini berdasarkan preferensi Anda sendiri karena akan menentukan pembayaran yang Anda peroleh, termasuk proses negosiasi yang Anda lakukan kepada petugas.
+              Anda dapat menghubungi kami setiap saat selama eksperimen jika ada hal-hal yang perlu Anda tanyakan mengenai prosedur eksperimen ini.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Pembayaran
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan mendapatkan dua bentuk pembayaran dari eksperimen yang Anda telah selesaikan: uang kehadiran sebesar Rp15.000 dan payoff dari salah satu ronde eksperimen.
+              Satu ronde dari seluruh ronde di masing-masing eksperimen akan diambil secara acak melalui distribusi seragam untuk menjadi basis pembayaran Anda.
+              Pembayaran (poin) yang Anda peroleh dari masing-masing eksperimen tersebut dikalikan dengan Rp50 untuk menjadi pembayaran final.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Langkah Selanjutnya
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan menuju ke survei pra-eksperimen setelah ini jika Anda telah mengerti dan setuju untuk mengikuti eksperimen ini.
+              Klik tanda ‘SETUJU’ di bawah ini.
+            </td>
+          </tr>
+        </table>
+
+        <div style="text-align: center; margin-top: 20px;">
+          <button>Setuju</button>
+        </div>
+      </div>
+
+
+    {% else %}
+      <!-- PETUGAS -->
+      <div style="
+        max-width: 800px;
+        margin: 40px auto;
+        padding: 20px;
+        border: 2px solid #000;
+        background-color: #fff;
+        line-height: 1.5;
+        text-align: justify;
+      ">
+
+        <h2 style="margin-top: 0;">
+          **** Instruksi untuk Petugas ****
+        </h2>
+        <h3>ANDA MENDAPATKAN PERAN SEBAGAI PETUGAS</h3>
+
+        <h4>Eksperimen</h4>
+        <p>
+          Sebagai seorang petugas, Anda diminta untuk melakukan pengecekan atas laporan impor barang mewah yang masuk oleh importir.
+          Anda dapat berkomunikasi dengan importir untuk mengubah kategori barang impor dari barang mewah menjadi barang biasa, atau mempertahankan kategori barang mewah tersebut.
+          Setelah komunikasi selesai, Anda akan diminta menentukan kategori barang impor tersebut dan meneruskannya ke otoritas pajak.
+          Akan terdapat auditor yang secara acak mengecek laporan pajak importir dan laporan kategori Anda.
+          Berikut adalah penjelasan umum eksperimen untuk Anda sebagai petugas pengecekan barang impor yang masuk:
+        </p>
+
+        <table style="width: 100%; border-collapse: collapse; border: 1px solid black;">
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top; width: 30%;">
+              Kategori Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Terdapat dua kategori barang impor dalam eksperimen ini: Barang Mewah dan Barang Biasa.
+              Kedua barang berbeda dalam pengenaan tarif pajaknya.
+              Namun, importir hanya akan mengimpor barang mewah di dalam eksperimen ini.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Harga dan Kuantitas Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Kuantitas barang yang Anda impor (<em>Q</em>) diambil secara acak dari distribusi normal dengan rata-rata {{C.MEAN_QUANTITY}} dan deviasi standar {{C.SD_QUANTITY}}.
+              Harga barang mewah yang Anda impor (<em>P</em>) akan selalu tetap untuk seluruh ronde yaitu {{C.FIXED_PRICE}} poin.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Nilai Tarif Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Eksperimen ini menggunakan tarif compound dengan penghitungan
+              <code>T = (Q * s) + (Q * P * t)</code>, di mana s adalah tarif spesifik yang dikenakan per unit barang
+              diimpor dan t adalah tarif ad valorem dalam bentuk persen dari total nilai impor.
+              Pengenaan tarif impor T didasarkan atas klasifikasi barang impor sebagai berikut:
+
+              <ul>
+                <li><em>Barang Mewah</em>: (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).</li>
+                <li><em>Barang Biasa</em>: (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).</li>
+              </ul>
+              Dalam hal ini, barang impor akan dikenakan pajak yang lebih murah ketika dikategorikan sebagai barang biasa daripada barang mewah.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Interaksi dengan Importir
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan dihubungkan dengan <strong> satu importir yang berbeda </strong> sepanjang eksperimen ini dan Anda dan importir akan berada di halaman yang sama pada saat pelaporan barang impor Anda.
+Importir yang akan membersamai Anda ditentukan secara acak sebelum ronde pertama dimulai dan bersifat anonim.
+Anda dapat berkomunikasi kepada importir melalui kolom chat.
+Anda dapat menerima, menolak, atau mengusulkan nominal transfer dari importir untuk mengubah kategori barang impor.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Proses Audit atas Laporan
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Petugas pajak mengirimkan laporan pajak Anda ke otoritas pajak. Petugas pajak bisa saja melaporkan jenis
+              barang yang berbeda dari yang didiskusikan sebelumnya. Auditor (komputer) akan mengumpulkan seluruh laporan
+              pajak yang dikirimkan oleh petugas pajak untuk diaudit. Laporan pajak Anda memiliki kemungkinan untuk menjadi
+              sampel audit sebesar 50%. Jika hasil audit menunjukkan Anda tidak melaporkan sesuai dengan nilai impor sesungguhnya,
+              maka Anda akan menerima denda. Petugas dapat menurunkan peluang laporan pajak Anda diaudit dengan mengirimkan transfer
+              ke Auditor. Setiap 1 poin yang dikirim petugas ke auditor akan menurunkan peluang audit sebesar 0.2% dan kemungkinan
+              terendah Anda akan terkena audit adalah 10%.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Denda atas Laporan yang Tidak Sesuai
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Jika laporan yang Anda teruskan menjadi sampel audit dan ditemukan ketidaksesuaian dari aslinya oleh Auditor,
+              maka Anda akan didenda sebesar upah menjadi petugas dan bagian yang Anda terima dari importir.
+              Dengan kata lain, Anda tidak mendapatkan apa-apa dari ronde tersebut dari denda yang ada.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Payoff di Setiap Ronde
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Payoff yang Anda terima berbasis pada upah menjadi petugas ({{C.SALARY}} poin) dan tambahan dari hasil negosiasi dengan importir dan Auditor.
+              Berikut penghitungan payoff Anda di setiap ronde:
+              <br><em>Upah petugas + poin transaksi (jika bekerja sama dalam pemalsuan laporan) – denda (jika terbukti melakukan pelanggaran)</em>.
+              <br>Namun payoff Anda akan hangus jika Auditor menemukan pemalsuan laporan dan Anda terlibat di dalamnya.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Durasi Eksperimen
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Kami mengestimasi penyelesaian rangkaian eksperimen ini selama lebih-kurang 90 menit.
+              Kami harap Anda menyelesaikan eksperimen ini berdasarkan preferensi Anda sendiri karena akan menentukan pembayaran yang Anda peroleh,
+              termasuk proses negosiasi yang Anda lakukan kepada petugas.
+              Anda dapat menghubungi kami setiap saat selama eksperimen jika ada hal-hal yang perlu Anda tanyakan mengenai prosedur eksperimen ini.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Pembayaran
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan mendapatkan dua bentuk pembayaran dari eksperimen yang Anda telah selesaikan: uang kehadiran sebesar Rp15.000 dan payoff dari salah satu ronde eksperimen.
+              Satu ronde dari seluruh ronde di masing-masing eksperimen akan diambil secara acak melalui distribusi seragam untuk menjadi basis pembayaran Anda.
+              Pembayaran (poin) yang Anda peroleh dari masing-masing eksperimen tersebut dikalikan dengan Rp50 untuk menjadi pembayaran final.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Langkah Selanjutnya
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan menuju ke survei pra-eksperimen setelah ini jika Anda telah mengerti dan setuju untuk mengikuti eksperimen ini.
+              Klik tanda ‘SETUJU’ di bawah ini.
+            </td>
+          </tr>
+        </table>
+
+      <div style="text-align: center; margin-top: 20px;">
+          <button>Setuju</button>
+      </div>
+    {% endif %}
+
+  </div>
+
+</form>
+
+<script>
+  function showPage(pageNumber) {
+    if (pageNumber === 2) {
+      document.getElementById("page1").style.display = "none";
+      document.getElementById("page2").style.display = "block";
+    }
+  }
+  function submitForm() {
+    document.getElementById("instructionsForm").submit();
+  }
+</script>
+
+{% endblock %}

--- a/compound_practice_random_besar_fixed/Investigation.html
+++ b/compound_practice_random_besar_fixed/Investigation.html
@@ -1,0 +1,44 @@
+{{ block title }}
+   Hasil (SESI LATIHAN)<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+
+{% if group.audit == True and group.category == "Barang Biasa" %}
+<p>
+    Hasil audit menemukan ketidaksesuaian pada pelaporan kategori.
+    Denda sebesar <strong>{{ player.penalty }} poin</strong> diberlakukan, <br>
+    {{ if player.role == "Importir" }}
+    Pendapatan akhir Anda adalah = Nilai Barang ({{ player.goods_value }}) - Biaya tarif ({{ player.tariff }}) - Kesepakatan transfer ({{ group.deal_price }}) - Denda ({{ player.penalty }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+    {{ if player.role == "Petugas Pajak" }}
+    Pendapatan akhir Anda adalah Gaji ({{C.SALARY}}) + Kesepakatan transfer ({{ group.deal_price }}) - Transfer ke auditor ({{player.bribe}}) - Denda ({{ player.penalty }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+</p>
+{% endif %}
+
+{% if group.audit == False or group.category == "Barang Mewah" %}
+<p>
+    Tidak ditemukan ketidaksesuaian dalam laporan Anda.
+    Total Tarif yang berlaku adalah = {{ player.tariff }} poin.<br>
+    {{ if player.role == "Importir" }}
+    Pendapatan akhir Anda adalah Nilai Barang ({{ player.goods_value }}) - Biaya tarif ({{ player.tariff }}) - Kesepakatan transfer ({{ group.deal_price }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+    {{ if player.role == "Petugas Pajak" }}
+    Pendapatan akhir Anda adalah Gaji ({{C.SALARY}}) + Kesepakatan transfer ({{ group.deal_price }}) - Transfer ke auditor ({{player.bribe}}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+</p>
+{% endif %}
+
+<hr>
+<p>
+    <strong>Jumlah Barang Diimpor:</strong> {{ group.quantity }}<br>
+    <strong>Kategori Barang Impor Dari Petugas: </strong> {{ group.category }}<br>
+    <strong>Total Tarif yang berlaku adalah = {{ player.tariff }}</strong><br>
+    <strong>Denda Saat Ini:</strong> {{ player.penalty }} poin
+</p>
+
+{{ next_button }}
+
+{{ endblock }}

--- a/compound_practice_random_besar_fixed/Results.html
+++ b/compound_practice_random_besar_fixed/Results.html
@@ -1,0 +1,42 @@
+{{ block title }}
+    Pengambilan Keputusan (SESI LATIHAN)<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+<p>
+    Kategori apa yang akan Anda berikan kepada barang impor tersebut?
+    {{ formfield 'category' }}
+</p>
+
+Nilai Barang = {{ player.goods_value }} poin<br>
+Tarif barang mewah = (jumlah barang × 3) +(jumlah barang × harga barang (20 poin) × 20%) = {{ player.mewah_tariff }} poin<br>
+Tarif barang biasa = (jumlah barang × 2) +(jumlah barang × harga barang (20 poin) × 15%) = {{ player.biasa_tariff }} poin<br>
+
+{{ if group.deal_price == 0 }}
+<p>
+    Tidak ada negosiasi, sehingga Anda tidak menerima transfer dari importir.
+</p>
+{{ next_button }}
+{{ endif }}
+<br><br>
+
+{{ if group.deal_price > 0 }}
+<p>
+    Anda menyepakati untuk menerima transfer sebesar <strong>{{ group.deal_price }} poin</strong>.
+</p>
+<p>
+    Kegiatan ini memiliki kemungkinan audit 50:50. Jika audit menemukan ketidaksesuaian,
+    denda sebesar <strong>{{ player.potential_penalty }} poin</strong> akan dikenakan pada Anda.
+</p>
+<p>
+    Anda juga berkesempatan memberikan transfer kepada auditor untuk mengurangi risiko audit. Setiap 1 poin yang dikirim petugas ke auditor akan menurunkan peluang audit sebesar 0.2% dan kemungkinan
+              terendah Anda akan terkena audit adalah 10%.
+</p>
+{{ formfield 'bribe' }}
+{{ next_button }}
+{{ endif }}
+
+<hr>
+
+{{ endblock }}

--- a/compound_practice_random_besar_fixed/Results2.html
+++ b/compound_practice_random_besar_fixed/Results2.html
@@ -1,0 +1,12 @@
+{{ block title }}
+    Anda telah menyelesaikan ronde terakhir pada sesi ini (SESI LATIHAN)
+{{ endblock }}
+{{ block content }}
+Setelah dilakukan pengacakan, terpilih ronde {{player.random_round}} sebagai ronde pembyaran Anda pada sesi ini. <br>
+Hasil Anda pada ronde tersebut adalah {{player.payment}} poin. Poin ini dikalikan Rp50 rupiah untuk pembayaran eksperimen yaitu {{player.payment}} x 50 + uang kehadiran Rp15000 = {{player.payoff}} <br><br>
+<button>
+    Lanjut
+</button><p></p>
+
+{{ endblock }}
+

--- a/compound_practice_random_besar_fixed/__init__.py
+++ b/compound_practice_random_besar_fixed/__init__.py
@@ -1,0 +1,332 @@
+from otree.api import *
+import random
+import math
+
+doc = """
+For oTree beginners, it would be simpler to implement this as a discrete-time game 
+by using multiple rounds, e.g. 10 rounds, where in each round both players can make a new proposal,
+or accept the value from the previous round.
+
+However, the discrete-time version has more limitations
+(fixed communication structure, limited number of iterations).
+
+Also, the continuous-time version works smoother & faster, 
+and is less resource-intensive since it all takes place in 1 page.
+"""
+
+
+class C(BaseConstants):
+    NAME_IN_URL = 'compound_practice_random_besar_fixed'
+    PLAYERS_PER_GROUP = 2
+    NUM_ROUNDS = 2
+
+    # Keep the roles, profits, salary, officer cost
+    SALARY = 3125
+    OFFICER_COST = 10
+    SELLER_ROLE = 'Importir'
+    BUYER_ROLE = 'Petugas Pajak'
+
+    # Parameters for quantity and product price
+    FIXED_PRICE = 20
+    MEAN_QUANTITY = 200
+    SD_QUANTITY = 40
+
+    # Specific tariff (ST) for Mewah vs. Biasa
+    ST_MEWAH = 3
+    ST_BIASA = 2
+
+
+
+class Subsession(BaseSubsession):
+    pass
+
+
+def creating_session(subsession: Subsession):
+    # BUGFIX: in oTree 5 the grouping hook must be a MODULE-LEVEL function named
+    # `creating_session` taking the subsession as its argument. The previous app
+    # defined it as a method `Subsession.creating_session(self)`, which oTree 5
+    # never calls, so no re-grouping ran and partners stayed fixed across rounds.
+    #
+    # Re-shuffle into new random groups EVERY round (called once per round at
+    # session creation). `fixed_id_in_group=True` keeps each participant's
+    # id_in_group -- and therefore their role (Importir / Petugas Pajak) -- fixed,
+    # so only the partner changes, not the role. (Random re-matching; a repeat
+    # pairing by chance is possible and acceptable -- this is not perfect-stranger
+    # matching.)
+    subsession.group_randomly(fixed_id_in_group=True)
+
+class Group(BaseGroup):
+    deal_price = models.IntegerField()
+    is_finished = models.BooleanField(initial=False)
+    chance = models.IntegerField(initial=0)
+    chance2 = models.FloatField(initial=0)
+    # New field to store the random quantity (so it remains consistent if page is refreshed)
+    quantity = models.IntegerField(initial=0)
+    category = models.StringField()
+    bribe_chance = models.FloatField(initial=0)
+    audit = models.BooleanField()
+
+
+class Player(BasePlayer):
+    usia = models.IntegerField(label="Usia Anda (Tahun):",
+                               min=18, max=60)
+    gender = models.StringField(widget=widgets.RadioSelect,
+                                label="Jenis kelamin:",
+                                choices=["Pria", "Wanita"])
+    edukasi = models.StringField(widget=widgets.RadioSelect,
+                                 label="Tingkat Pendidikan yang sedang atau telah Anda tempuh:",
+                                 choices=["Diploma 3 (D3)",
+                                          "Sarjana/Diploma 4 (S1/D4)",
+                                          "Magister (S2)",
+                                          "Doktoral (S3)",
+                                          ])
+    provinsi = models.IntegerField(label="Tempat asal Provinsi",
+                                   choices=[[1, 'ACEH'], [2, 'BALI'], [3, 'BANTEN'], [4, 'BENGKULU'],
+                                            [5, 'DI YOGYAKARTA'], [6, 'DKI JAKARTA'],
+                                            [7, 'GORONTALO'], [8, 'JAMBI'], [9, 'JAWA BARAT'], [10, 'JAWA TENGAH'],
+                                            [11, 'JAWA TIMUR'],
+                                            [12, 'KALIMANTAN BARAT'], [13, 'KALIMANTAN SELATAN'],
+                                            [14, 'KALIMANTAN TENGAH'],
+                                            [15, 'KALIMANTAN TIMUR'], [16, 'KALIMANTAN UTARA'],
+                                            [17, 'KEPULAUAN BANGKA BELITUNG'],
+                                            [18, 'KEPULAUAN RIAU'], [19, 'LAMPUNG'], [20, 'MALUKU'],
+                                            [21, 'MALUKU UTARA'], [22, 'NUSA TENGGARA BARAT'],
+                                            [23, 'NUSA TENGGARA TIMUR'], [24, 'PAPUA'], [25, 'PAPUA BARAT'],
+                                            [26, 'PAPUA BARAT DAYA'],
+                                            [27, 'PAPUA PEGUNUNGAN'], [28, 'PAPUA SELATAN'], [29, 'PAPUA TENGAH'],
+                                            [30, 'RIAU'], [31, 'SULAWESI BARAT'],
+                                            [32, 'SULAWESI SELATAN'], [33, 'SULAWESI TENGAH'],
+                                            [34, 'SULAWESI TENGGARA'], [35, 'SULAWESI UTARA'],
+                                            [36, 'SUMATERA BARAT'], [37, 'SUMATERA SELATAN'], [38, 'SUMATERA UTARA']])
+    fakultas = models.StringField()
+    amount_proposed = models.IntegerField()
+    amount_accepted = models.IntegerField()
+    mewah_tariff = models.FloatField()
+    biasa_tariff = models.FloatField()
+    goods_value = models.FloatField()
+    pay = models.FloatField(initial=0)
+    tariff = models.FloatField(initial=0)
+    chance = models.IntegerField(initial=0)
+    bribe = models.IntegerField(blank=True, label="Iuran kepada auditor")
+    category = models.PositiveIntegerField(
+        choices=[[0, 'Barang Mewah'], [1, 'Barang Biasa']],
+        widget=widgets.RadioSelectHorizontal,
+        label="katagori barang"
+    )
+    payment = models.FloatField(initial=0)
+    penalty = models.FloatField(initial=0)
+    potential_penalty = models.FloatField(initial=0)
+    random_round = models.PositiveIntegerField()
+    rekening = models.StringField(label="Nomor Rekening")
+    tipe_pembayaran = models.StringField(widget=widgets.RadioSelect,
+                                label="Tipe Pembayaran",
+                                choices=["Gopay", "Ovo","Shopee","BNI","Mandiri","BCA","BRI"])
+    tipe_pembayaran_lain = models.StringField(
+        blank=True,
+        label="Jika lainnya, sebutkan:"
+    )
+    nomor_hp = models.StringField(label="Telepon")
+
+
+class Bargain(Page):
+    timeout_seconds = 180
+
+    @staticmethod
+    def vars_for_template(player: Player):
+        """Randomize quantity (once) and show possible tariffs for Barang Mewah & Biasa."""
+        group = player.group
+
+        # Randomize quantity only once per group (if not yet set).
+        if group.quantity == 0:
+            q = max(1, int(random.gauss(C.MEAN_QUANTITY, C.SD_QUANTITY)))
+            group.quantity = q
+
+        # Compute possible tariffs for demonstration (e.g. to show on the template).
+        player.goods_value = group.quantity * C.FIXED_PRICE
+
+        # Compound tariff for Mewah
+        player.mewah_tariff = (group.quantity*C.ST_MEWAH) + (group.quantity * C.FIXED_PRICE * 0.20)
+        # Compound tariff for Biasa
+        player.biasa_tariff = (group.quantity*C.ST_BIASA) + (group.quantity * C.FIXED_PRICE * 0.15)
+
+        return dict(
+            other_role=player.get_others_in_group()[0].role,
+            quantity=group.quantity,
+            mewah_tariff=int(player.mewah_tariff),
+            biasa_tariff=int(player.biasa_tariff),
+        )
+
+    @staticmethod
+    def js_vars(player: Player):
+        return dict(my_id=player.id_in_group)
+
+    @staticmethod
+    def live_method(player: Player, data):
+        group = player.group
+        [other] = player.get_others_in_group()
+
+        if 'amount' in data:
+            try:
+                amount = int(data['amount'])
+            except Exception:
+                print('Invalid message received', data)
+                return
+            if data['type'] == 'accept':
+                if amount == other.amount_proposed:
+                    player.amount_accepted = amount
+                    group.deal_price = amount
+                    group.is_finished = True
+                    return {0: dict(finished=True)}
+            if data['type'] == 'propose':
+                player.amount_proposed = amount
+            if data['type'] == 'reject':
+                if amount == other.amount_proposed:
+                    player.amount_accepted = 0
+                    group.deal_price = 0
+                    group.is_finished = True
+                    return {0: dict(finished=True)}
+
+        proposals = []
+        for p in [player, other]:
+            amount_proposed = p.field_maybe_none('amount_proposed')
+            if amount_proposed is not None:
+                proposals.append([p.id_in_group, amount_proposed])
+        return {0: dict(proposals=proposals)}
+
+    @staticmethod
+    def error_message(player: Player, values):
+        group = player.group
+        if not group.is_finished:
+            return "Game not finished yet"
+
+    @staticmethod
+    def is_displayed(player: Player):
+        """Skip this page if a deal has already been made"""
+        group = player.group
+        deal_price = group.field_maybe_none('deal_price')
+        return deal_price is None
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        """Use the new tariff scheme to compute player's payoff."""
+        group = player.group
+        if player.role == "Importir":
+            player.potential_penalty = 1.5 * player.mewah_tariff
+        else:
+            player.potential_penalty = 0.5 * C.SALARY
+        if timeout_happened:
+            player.amount_accepted = 0
+            player.amount_proposed = 0
+            group.deal_price = 0
+
+        # Compute tariff based on whether a 'deal_price' (bribe) was reached.
+        # If deal_price == 0 => treat as Barang Mewah
+        # If deal_price > 0 => treat as Barang Biasa
+        goods_value = group.quantity * C.FIXED_PRICE
+
+
+        if group.deal_price == 0:
+            # Barang Mewah
+            player.tariff = player.mewah_tariff
+            if player.role == "Importir":
+                player.pay = goods_value - player.tariff
+            else:
+                player.pay = C.SALARY
+        else:
+            # Barang Biasa
+            player.tariff = player.biasa_tariff
+            if player.role == "Importir":
+                # Importer pays the bribe plus the tariff
+                player.pay = goods_value - player.tariff - group.deal_price
+            else:
+                # Officer receives the bribe, minus cost
+                player.pay = C.SALARY + group.deal_price
+
+
+class Results(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.role == "Petugas Pajak"
+
+    form_model = 'player'
+    form_fields = ['bribe', 'category']
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        group = player.group
+        if player.category == 0:
+            group.category = "Barang Mewah"
+        else:
+            group.category = "Barang Biasa"
+        players = group.get_players()
+        bribe = player.field_maybe_none('bribe')
+        group.chance = random.randint(1,200)
+        if bribe is None:
+            player.bribe = 0
+        else:
+            if player.role == "Petugas Pajak":
+                player.pay = C.SALARY + group.deal_price - player.bribe
+            if player.bribe > 80:
+                bribe = 80
+            player.chance = bribe
+        group.bribe_chance = player.chance
+
+
+
+class ResultsWaitPage(WaitPage):
+    pass
+
+
+class Investigation(Page):
+    @staticmethod
+    def vars_for_template(player: Player):
+        group = player.group
+        if group.category == "Barang Biasa":
+            player.tariff = player.biasa_tariff
+            group.chance2 = 100 - group.bribe_chance
+            if group.chance < group.chance2:
+                group.audit = True
+                if player.role == "Importir":
+                    player.penalty = 1.5 * player.tariff
+                else:
+                    player.penalty = 0.5 * C.SALARY
+            else:
+                group.audit = False
+                player.penalty = 0
+        else:
+            player.tariff = player.mewah_tariff
+            player.penalty = 0
+            group.audit = False
+        player.payment = player.pay - player.penalty
+        if player.payment < 0:
+            player.payment = 0
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        import random
+        participant = player.participant
+
+        # if it's the last round
+        if player.round_number == C.NUM_ROUNDS:
+            random_round = random.randint(1, C.NUM_ROUNDS)
+            participant.selected_round = random_round
+            player.random_round = random_round
+            player_in_selected_round = player.in_round(random_round)
+            player.payoff = (player.payment*50) + 15000
+
+class MyWaitPage(WaitPage):
+    wait_for_all_groups = True
+
+class Instructions(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.round_number == 1
+
+class demographic(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.round_number == 1
+    form_model = 'player'
+    form_fields = ['provinsi', 'usia', 'gender', 'fakultas', 'edukasi']
+
+page_sequence = [Instructions, demographic, ResultsWaitPage, Bargain, Results, ResultsWaitPage, Investigation, MyWaitPage]

--- a/compound_practice_random_besar_fixed/demographic.html
+++ b/compound_practice_random_besar_fixed/demographic.html
@@ -1,0 +1,11 @@
+{{ block title }}
+    Survey
+{{ endblock }}
+{{ block content }}
+    <h3>Mohon isi kuesioner ini dengan sebenar-benarnya; termasuk platform pembayaran online.
+        Eksperimenter tidak akan membagikan data yang Anda berikan kepada siapapun</h3><br>
+    {{ formfields }}
+<br><p></p>
+<button class="otree-btn-next btn btn-primary next-button otree-next-button">Lanjut</button>
+
+{{ endblock }}

--- a/compound_practice_random_kecil_fixed/Bargain.html
+++ b/compound_practice_random_kecil_fixed/Bargain.html
@@ -1,0 +1,185 @@
+{{ block title }}
+Pelaporan Pajak (SESI LATIHAN)<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+
+<!-- Minimal CSS styling for a cleaner look -->
+<style>
+    .section-box {
+        margin-bottom: 1.5em;
+        padding: 1em;
+        background-color: #f9f9f9;
+        border: 1px solid #ddd;
+        border-radius: 5px;
+        line-height: 1.5;
+    }
+    .section-box h2 {
+        margin-top: 0;
+    }
+    .section-box ul {
+        margin-top: 0.5em;
+        margin-bottom: 0.5em;
+        padding-left: 1.5em;
+    }
+    .negotiation-table {
+        border-collapse: collapse;
+        width: 100%;
+        margin-top: 1em;
+    }
+    .negotiation-table th,
+    .negotiation-table td {
+        border: 1px solid #ccc;
+        padding: 0.5em;
+    }
+    .debug-section {
+        margin-top: 1em;
+        padding: 0.5em;
+        background-color: #fefefe;
+        border: 1px dashed #ccc;
+    }
+</style>
+
+{{ if player.role == "Importir" }}
+<div class="section-box">
+    <h2>Importir</h2>
+    <p>
+        Anda merupakan importir barang mewah yang berpotensi meraih keuntungan.
+        Saat ini, Anda mengimpor sejumlah <strong>{{ quantity }}</strong> unit.
+        Nilai barang = jumlah barang × harga (20 poin), sehingga nilai barang Anda adalah <strong>{{ player.goods_value }}</strong> poin.
+    </p>
+    <p>
+        Apabila barang dikategorikan sebagai <em>Barang Mewah</em>, tarif dihitung sebagai:
+        <br>
+        (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).
+        <br>
+        Nilai tarif barang mewah adalah <strong>{{ mewah_tariff }}</strong> poin.
+    </p>
+    <p>
+        Anda dapat bernegosiasi dengan petugas pajak untuk mengubah kategori menjadi <em>Barang Biasa</em>, sehingga tarif dihitung sebagai:
+        <br>
+        (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).
+        <br>
+        Nilai tarif barang biasa adalah <strong>{{ biasa_tariff }}</strong> poin.
+        Hasil kesepakatan Anda dengan petugas pajak tidak menjamin kategori akan berubah karena keputusan akhir ada di petugas pajak.
+    </p>
+    <p>
+        Jika terjadi audit (50:50) dan ditemukan ketidaksesuaian, maka denda sebesar 1.5 × nilai tarif akan dikenakan ke Anda.
+    </p>
+</div>
+{{ endif }}
+
+{{ if player.role == "Petugas Pajak" }}
+<div class="section-box">
+    <h2>Petugas Pajak</h2>
+    <p>
+        Anda merupakan petugas pajak impor dengan gaji <strong>{{C.SALARY}}</strong> poin.
+        Anda menentukan kategori barang (Mewah/Barang Biasa) dan menghitung tarif berikut:
+    </p>
+    <ul>
+        <li><em>Barang Mewah</em>: (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).</li>
+        <li><em>Barang Biasa</em>: (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).</li>
+    </ul>
+    <p>
+        Saat ini, jumlah barang mewah yang diimpor adalah sebanyak <strong>{{ quantity }}</strong> unit dengan nilai sebesar <strong>{{ player.goods_value }}</strong> poin.
+        Apabila barang dikategorikan sebagai <em>Barang Mewah</em>, maka nilai tarif = <strong>{{ mewah_tariff }}</strong> poin.
+        Apabila barang dikategorikan sebagai <em>Barang Biasa</em>, maka nilai tarif = <strong>{{ biasa_tariff }}</strong> poin.
+    </p>
+    <p>
+        Importir memiliki potensi keuntungan dan dapat menawarkan transfer kepada Anda agar barang dikategorikan sebagai Barang Biasa.
+        Namun, keputusan akhir ada di tangan Anda.
+        Jika terjadi audit (50:50) dan ditemukan ketidaksesuaian, maka denda sebesar 50% gaji akan dikenakan ke Anda.
+    </p>
+</div>
+{{ endif }}
+
+<p>
+    Silakan bernegosiasi dengan {{ other_role }} mengenai besaran transfer. Jika tidak tercapai kesepakatan,
+    tarif impor akan dikenakan penuh sesuai kategori awal, tanpa transfer.
+</p>
+
+<table class="negotiation-table">
+    <tr>
+        <th>Proposal Transfer Anda</th>
+        <td id="my-proposal">(none)</td>
+        <td>
+            <input type="number" id="my_offer">
+            <button type="button" onclick="sendOffer()" id="btn-offer">Ajukan Transfer</button>
+        </td>
+    </tr>
+
+    <tr>
+        <th>Proposal Transfer {{ other_role }}</th>
+        <td id="other-proposal">(none)</td>
+{{ if player.role == "Petugas Pajak" }}
+        <td>
+            <button type="button" id="btn-accept" onclick="sendAccept(this)" style="display: none">Terima</button>
+        </td>
+        <td>
+            <button type="button" id="btn-reject" onclick="sendReject(this)" style="display: none">Tolak</button>
+        </td>
+    </tr>
+{{ endif }}
+</table>
+
+<h4>Chat</h4>
+{{ chat nickname=player.role }}
+
+<!-- No changes to JavaScript below -->
+<script>
+    let my_offer = document.getElementById('my_offer');
+    let btnAccept = document.getElementById('btn-accept');
+    let btnReject = document.getElementById('btn-reject');
+    let msgOtherProposal = document.getElementById('other-proposal');
+    let msgMyProposal = document.getElementById('my-proposal');
+
+    let otherProposal;
+
+    my_offer.addEventListener("keydown", function (event) {
+        if (event.key === "Enter") {
+            sendOffer();
+        }
+    });
+
+    function sendOffer() {
+        liveSend({'type': 'propose', 'amount': my_offer.value})
+        my_offer.value = '';
+    }
+
+    function sendAccept() {
+        liveSend({'type': 'accept', 'amount': otherProposal})
+    }
+
+    function sendReject() {
+        liveSend({'type': 'reject', 'amount': otherProposal})
+    }
+
+    function cu(amount) {
+        return `${amount} poin`;
+    }
+
+    function liveRecv(data) {
+        if ('proposals' in data) {
+            for (let [id_in_group, proposal] of data.proposals) {
+                if (id_in_group === js_vars.my_id) {
+                    msgMyProposal.innerHTML = cu(proposal);
+                } else {
+                    msgOtherProposal.innerHTML = cu(proposal);
+                    otherProposal = proposal;
+                    btnAccept.style.display = 'block';
+                    btnReject.style.display = 'block';
+                }
+            }
+        }
+        if ('finished' in data) {
+            document.getElementById('form').submit();
+        }
+    }
+
+    window.addEventListener('DOMContentLoaded', (event) => {
+        liveSend({});
+    });
+</script>
+
+{{ endblock }}

--- a/compound_practice_random_kecil_fixed/Instructions.html
+++ b/compound_practice_random_kecil_fixed/Instructions.html
@@ -1,0 +1,378 @@
+{% extends "global/Page.html" %}
+{% block content %}
+
+<form id="instructionsForm" method="post" style="margin: 0; padding: 0;">
+
+  <!-- PAGE 1: General Instructions -->
+  <div id="page1" style="display: block;">
+    <div style="
+      max-width: 800px;
+      margin: 40px auto;
+      padding: 20px;
+      border: 2px solid #000;
+      background-color: #fff;
+      line-height: 1.5;
+      text-align: justify;
+    ">
+      <h2 style="text-align: center; margin-top: 0;">INSTRUKSI</h2>
+
+      <p>
+        Selamat datang dan terima kasih telah bersedia untuk mengikuti eksperimen ini.
+        Mohon baca instruksi ini dengan seksama agar Anda memahami apa yang harus Anda lakukan di dalam eksperimen ini.
+        Eksperimen ini memberikan Anda kesempatan untuk memperoleh uang tunai yang akan dibayarkan segera setelah Anda menyelesaikan rangkaian eksperimen ini.
+        Besaran uang yang akan Anda peroleh bergantung pada apa yang Anda dan rekan Anda lakukan di dalam eksperimen ini.
+        Oleh karenanya, mohon untuk serius dalam menyelesaikannya sesuai dengan preferensi Anda.
+      </p>
+
+      <p>
+        Eksperimen ini bertujuan untuk memahami perilaku dan interaksi yang terjadi di dalam sebuah pelaporan dan pengecekan barang impor.
+        Anda akan ditempatkan secara acak apakah menjadi seorang importir barang atau petugas yang melakukan cek atas barang impor sepanjang eksperimen ini.
+        Jumlah importir dan petugas akan sama di satu sesi eksperimen. Anda akan menghadapi 20 ronde dengan tipikal yang sama sesuai peran Anda masing-masing:
+        seorang importir atau petugas. Peserta akan berinteraksi satu sama lain dalam 3 menit per rondenya.
+        Anda bisa berkomunikasi dengan lawan main di setiap ronde melalui kolom chat yang tersedia. Seluruh peserta akan menyelesaikan eksperimen ini secara bersamaan.
+        Selain itu, Anda juga akan diminta untuk mengisi kuesioner singkat setelah Anda menyelesaikan eksperimen ini.
+      </p>
+
+      <p>
+        Eksperimen ini telah mendapatkan persetujuan dari Komisi Etik Direktorat Penelitian UGM.
+        Lembar persetujuan terinformasi telah dikirim bersamaan dengan email undangan dan telah Anda setujui. Anda dapat melihat kembali lembar tersebut di <a href="
+        https://drive.google.com/file/d/1eS9WdjCHcOSkZf494_D67Rge-8DPnUFr/view?usp=sharing" target="_blank">https://drive.google.com/file/d/1eS9WdjCHcOSkZf494_D67Rge-8DPnUFr/view?usp=sharing</a>
+      </p>
+
+      <p>
+        Silakan klik tombol <strong>LANJUT</strong> di bawah ini untuk mendapatkan acakan peran di dalam eksperimen ini.
+      </p>
+
+      <div style="text-align: center;">
+        <button type="button" onclick="showPage(2)">LANJUT</button>
+      </div>
+
+      <p style="text-align: center; margin-top: 30px;">
+        <em>Tim Peneliti</em>
+      </p>
+    </div>
+  </div>
+
+
+  <!-- PAGE 2: Role-Specific Instructions with lined tables -->
+  <div id="page2" style="display: none;">
+    {% if player.role == "Importir" %}
+      <!-- IMPORTIR -->
+      <div style="
+        max-width: 800px;
+        margin: 40px auto;
+        padding: 20px;
+        border: 2px solid #000;
+        background-color: #fff;
+        line-height: 1.5;
+        text-align: justify;
+      ">
+
+        <h2 style="margin-top: 0;">
+          **** Instruksi untuk Importir ****
+        </h2>
+        <h3>ANDA MENDAPATKAN PERAN SEBAGAI IMPORTIR BARANG</h3>
+
+        <h4>Eksperimen</h4>
+        <p>
+          Sebagai seorang importir, Anda melakukan impor barang mewah dengan nilai tertentu di mana barang impor tersebut akan dikenai tarif impor barang mewah.
+          Besaran tarif impor barang mewah bergantung dari jumlah dan harga barang yang Anda impor.
+          Di setiap ronde, Anda harus melaporkan nilai dari barang yang Anda impor kepada petugas untuk dihitung nilai tarif impornya yang akan menjadi tanggungan Anda.
+          Anda dapat berkomunikasi kepada petugas melalui kolom chat.
+          Akan terdapat auditor yang secara acak mengecek laporan pajak Anda.
+          Berikut adalah penjelasan umum eksperimen untuk Anda sebagai importir barang:
+        </p>
+
+        <table style="width: 100%; border-collapse: collapse; border: 1px solid black;">
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top; width: 30%;">
+              Kategori Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Terdapat dua kategori barang impor dalam eksperimen ini: Barang Mewah dan Barang Biasa.
+              Kedua barang berbeda dalam pengenaan tarif pajaknya.
+              Namun, Anda hanya akan mengimpor barang mewah di dalam eksperimen ini.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Harga dan Kuantitas Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Kuantitas barang yang Anda impor (<em>Q</em>) diambil secara acak dari distribusi normal dengan rata-rata {{C.MEAN_QUANTITY}} dan deviasi standar {{C.SD_QUANTITY}}.
+              Harga barang mewah yang Anda impor (<em>P</em>) akan selalu tetap untuk seluruh ronde yaitu {{C.FIXED_PRICE}} poin.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Nilai Tarif Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Eksperimen ini menggunakan tarif compound dengan penghitungan
+              <code>T = (Q * s) + (Q * P * t)</code>, di mana s adalah tarif spesifik yang dikenakan per unit barang
+              diimpor dan t adalah tarif ad valorem dalam bentuk persen dari total nilai impor.
+              Pengenaan tarif impor T didasarkan atas klasifikasi barang impor sebagai berikut:
+
+              <ul>
+                <li><em>Barang Mewah</em>: (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).</li>
+                <li><em>Barang Biasa</em>: (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).</li>
+              </ul>
+              Dalam hal ini, barang impor akan dikenakan pajak yang lebih murah ketika dikategorikan sebagai barang biasa daripada barang mewah.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Interaksi dengan Petugas Pajak
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan dihubungkan dengan <strong> satu petugas pajak yang berbeda </strong> sepanjang eksperimen ini yang tugasnya adalah memastikan pelaporan barang yang Anda impor.
+              Anda dan petugas pajak akan berada di halaman yang sama pada saat pelaporan barang impor Anda.
+              Petugas pajak yang akan membersamai Anda ditentukan secara acak sebelum ronde pertama dimulai dan bersifat anonim.
+              Anda dapat berkomunikasi kepada petugas melalui kolom chat dan Anda dapat mengirimkan transfer kepada petugas pajak untuk mengubah kategori barang impor Anda.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Proses Audit atas Laporan Petugas Pajak
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Petugas pajak mengirimkan laporan pajak Anda ke otoritas pajak. Petugas pajak bisa saja melaporkan jenis
+              barang yang berbeda dari yang didiskusikan sebelumnya. Auditor (komputer) akan mengumpulkan seluruh laporan
+              pajak yang dikirimkan oleh petugas pajak untuk diaudit. Laporan pajak Anda memiliki kemungkinan untuk menjadi
+              sampel audit sebesar 50%. Jika hasil audit menunjukkan Anda tidak melaporkan sesuai dengan nilai impor sesungguhnya,
+              maka Anda akan menerima denda. Petugas dapat menurunkan peluang laporan pajak Anda diaudit dengan mengirimkan transfer
+              ke Auditor. Setiap 1 poin yang dikirim petugas ke auditor akan menurunkan peluang audit sebesar 1% dan kemungkinan
+              terendah Anda akan terkena audit adalah 10%.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Denda atas Laporan yang Tidak Sesuai
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Jika hasil audit menunjukkan laporan yang tidak sesuai, maka denda yang Anda terima adalah sebesar 150% dari nilai tarif yang Anda bayarkan.
+              Denda ini di luar nilai tarif yang telah Anda bayarkan berdasarkan laporan yang Anda berikan.
+              Transfer Anda kepada petugas dalam proses negosiasi akan hangus dan tidak dikembalikan kepada Anda.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Payoff di Setiap Ronde
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Basis payoff Anda adalah nilai barang impor yang Anda lakukan dan proses yang terjadi setelahnya.
+              Payoff dari setiap ronde akan diinformasikan setelah suatu ronde berakhir dengan penghitungan sebagai berikut:
+              <br><em>Nilai barang yang diimpor – pajak impor (berdasarkan laporan Anda) – nilai transaksi negosiasi (jika ada) – denda (jika ada)</em>.
+              <br>Jika payoff terhitung Anda adalah negatif, maka payoff Anda di ronde tersebut adalah nol.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Catatan Penting
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda dan petugas akan berada pada halaman yang sama di setiap ronde pada saat proses pelaporan.
+              Anda (tidak) akan diinformasikan lawan main (petugas pajak) di setiap ronde.
+              Informasi tersebut berupa kode partisipan masing-masing partisipan mengacu pada nomor meja.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Durasi Eksperimen
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Kami mengestimasi penyelesaian rangkaian eksperimen ini selama lebih-kurang 90 menit.
+              Kami harap Anda menyelesaikan eksperimen ini berdasarkan preferensi Anda sendiri karena akan menentukan pembayaran yang Anda peroleh, termasuk proses negosiasi yang Anda lakukan kepada petugas.
+              Anda dapat menghubungi kami setiap saat selama eksperimen jika ada hal-hal yang perlu Anda tanyakan mengenai prosedur eksperimen ini.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Pembayaran
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan mendapatkan dua bentuk pembayaran dari eksperimen yang Anda telah selesaikan: uang kehadiran sebesar Rp15.000 dan payoff dari salah satu ronde eksperimen.
+              Satu ronde dari seluruh ronde di masing-masing eksperimen akan diambil secara acak melalui distribusi seragam untuk menjadi basis pembayaran Anda.
+              Pembayaran (poin) yang Anda peroleh dari masing-masing eksperimen tersebut dikalikan dengan Rp50 untuk menjadi pembayaran final.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Langkah Selanjutnya
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan menuju ke survei pra-eksperimen setelah ini jika Anda telah mengerti dan setuju untuk mengikuti eksperimen ini.
+              Klik tanda ‘SETUJU’ di bawah ini.
+            </td>
+          </tr>
+        </table>
+
+        <div style="text-align: center; margin-top: 20px;">
+          <button>Setuju</button>
+        </div>
+      </div>
+
+
+    {% else %}
+      <!-- PETUGAS -->
+      <div style="
+        max-width: 800px;
+        margin: 40px auto;
+        padding: 20px;
+        border: 2px solid #000;
+        background-color: #fff;
+        line-height: 1.5;
+        text-align: justify;
+      ">
+
+        <h2 style="margin-top: 0;">
+          **** Instruksi untuk Petugas ****
+        </h2>
+        <h3>ANDA MENDAPATKAN PERAN SEBAGAI PETUGAS</h3>
+
+        <h4>Eksperimen</h4>
+        <p>
+          Sebagai seorang petugas, Anda diminta untuk melakukan pengecekan atas laporan impor barang mewah yang masuk oleh importir.
+          Anda dapat berkomunikasi dengan importir untuk mengubah kategori barang impor dari barang mewah menjadi barang biasa, atau mempertahankan kategori barang mewah tersebut.
+          Setelah komunikasi selesai, Anda akan diminta menentukan kategori barang impor tersebut dan meneruskannya ke otoritas pajak.
+          Akan terdapat auditor yang secara acak mengecek laporan pajak importir dan laporan kategori Anda.
+          Berikut adalah penjelasan umum eksperimen untuk Anda sebagai petugas pengecekan barang impor yang masuk:
+        </p>
+
+        <table style="width: 100%; border-collapse: collapse; border: 1px solid black;">
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top; width: 30%;">
+              Kategori Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Terdapat dua kategori barang impor dalam eksperimen ini: Barang Mewah dan Barang Biasa.
+              Kedua barang berbeda dalam pengenaan tarif pajaknya.
+              Namun, importir hanya akan mengimpor barang mewah di dalam eksperimen ini.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Harga dan Kuantitas Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Kuantitas barang yang Anda impor (<em>Q</em>) diambil secara acak dari distribusi normal dengan rata-rata {{C.MEAN_QUANTITY}} dan deviasi standar {{C.SD_QUANTITY}}.
+              Harga barang mewah yang Anda impor (<em>P</em>) akan selalu tetap untuk seluruh ronde yaitu {{C.FIXED_PRICE}} poin.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Nilai Tarif Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Eksperimen ini menggunakan tarif compound dengan penghitungan
+              <code>T = (Q * s) + (Q * P * t)</code>, di mana s adalah tarif spesifik yang dikenakan per unit barang
+              diimpor dan t adalah tarif ad valorem dalam bentuk persen dari total nilai impor.
+              Pengenaan tarif impor T didasarkan atas klasifikasi barang impor sebagai berikut:
+
+              <ul>
+                <li><em>Barang Mewah</em>: (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).</li>
+                <li><em>Barang Biasa</em>: (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).</li>
+              </ul>
+              Dalam hal ini, barang impor akan dikenakan pajak yang lebih murah ketika dikategorikan sebagai barang biasa daripada barang mewah.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Interaksi dengan Importir
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan dihubungkan dengan <strong> satu importir yang berbeda </strong> sepanjang eksperimen ini dan Anda dan importir akan berada di halaman yang sama pada saat pelaporan barang impor Anda.
+Importir yang akan membersamai Anda ditentukan secara acak sebelum ronde pertama dimulai dan bersifat anonim.
+Anda dapat berkomunikasi kepada importir melalui kolom chat.
+Anda dapat menerima, menolak, atau mengusulkan nominal transfer dari importir untuk mengubah kategori barang impor.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Proses Audit atas Laporan
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Petugas pajak mengirimkan laporan pajak Anda ke otoritas pajak. Petugas pajak bisa saja melaporkan jenis
+              barang yang berbeda dari yang didiskusikan sebelumnya. Auditor (komputer) akan mengumpulkan seluruh laporan
+              pajak yang dikirimkan oleh petugas pajak untuk diaudit. Laporan pajak Anda memiliki kemungkinan untuk menjadi
+              sampel audit sebesar 50%. Jika hasil audit menunjukkan Anda tidak melaporkan sesuai dengan nilai impor sesungguhnya,
+              maka Anda akan menerima denda. Petugas dapat menurunkan peluang laporan pajak Anda diaudit dengan mengirimkan transfer
+              ke Auditor. Setiap 1 poin yang dikirim petugas ke auditor akan menurunkan peluang audit sebesar 1% dan kemungkinan
+              terendah Anda akan terkena audit adalah 10%.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Denda atas Laporan yang Tidak Sesuai
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Jika laporan yang Anda teruskan menjadi sampel audit dan ditemukan ketidaksesuaian dari aslinya oleh Auditor,
+              maka Anda akan didenda sebesar upah menjadi petugas dan bagian yang Anda terima dari importir.
+              Dengan kata lain, Anda tidak mendapatkan apa-apa dari ronde tersebut dari denda yang ada.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Payoff di Setiap Ronde
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Payoff yang Anda terima berbasis pada upah menjadi petugas ({{C.SALARY}} poin) dan tambahan dari hasil negosiasi dengan importir dan Auditor.
+              Berikut penghitungan payoff Anda di setiap ronde:
+              <br><em>Upah petugas + poin transaksi (jika bekerja sama dalam pemalsuan laporan) – denda (jika terbukti melakukan pelanggaran)</em>.
+              <br>Namun payoff Anda akan hangus jika Auditor menemukan pemalsuan laporan dan Anda terlibat di dalamnya.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Durasi Eksperimen
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Kami mengestimasi penyelesaian rangkaian eksperimen ini selama lebih-kurang 90 menit.
+              Kami harap Anda menyelesaikan eksperimen ini berdasarkan preferensi Anda sendiri karena akan menentukan pembayaran yang Anda peroleh,
+              termasuk proses negosiasi yang Anda lakukan kepada petugas.
+              Anda dapat menghubungi kami setiap saat selama eksperimen jika ada hal-hal yang perlu Anda tanyakan mengenai prosedur eksperimen ini.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Pembayaran
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan mendapatkan dua bentuk pembayaran dari eksperimen yang Anda telah selesaikan: uang kehadiran sebesar Rp15.000 dan payoff dari salah satu ronde eksperimen.
+              Satu ronde dari seluruh ronde di masing-masing eksperimen akan diambil secara acak melalui distribusi seragam untuk menjadi basis pembayaran Anda.
+              Pembayaran (poin) yang Anda peroleh dari masing-masing eksperimen tersebut dikalikan dengan Rp50 untuk menjadi pembayaran final.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Langkah Selanjutnya
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan menuju ke survei pra-eksperimen setelah ini jika Anda telah mengerti dan setuju untuk mengikuti eksperimen ini.
+              Klik tanda ‘SETUJU’ di bawah ini.
+            </td>
+          </tr>
+        </table>
+
+      <div style="text-align: center; margin-top: 20px;">
+          <button>Setuju</button>
+      </div>
+    {% endif %}
+
+  </div>
+
+</form>
+
+<script>
+  function showPage(pageNumber) {
+    if (pageNumber === 2) {
+      document.getElementById("page1").style.display = "none";
+      document.getElementById("page2").style.display = "block";
+    }
+  }
+  function submitForm() {
+    document.getElementById("instructionsForm").submit();
+  }
+</script>
+
+{% endblock %}

--- a/compound_practice_random_kecil_fixed/Investigation.html
+++ b/compound_practice_random_kecil_fixed/Investigation.html
@@ -1,0 +1,44 @@
+{{ block title }}
+   Hasil (SESI LATIHAN)<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+
+{% if group.audit == True and group.category == "Barang Biasa" %}
+<p>
+    Hasil audit menemukan ketidaksesuaian pada pelaporan kategori.
+    Denda sebesar <strong>{{ player.penalty }} poin</strong> diberlakukan, <br>
+    {{ if player.role == "Importir" }}
+    Pendapatan akhir Anda adalah = Nilai Barang ({{ player.goods_value }}) - Biaya tarif ({{ player.tariff }}) - Kesepakatan transfer ({{ group.deal_price }}) - Denda ({{ player.penalty }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+    {{ if player.role == "Petugas Pajak" }}
+    Pendapatan akhir Anda adalah Gaji ({{C.SALARY}}) + Kesepakatan transfer ({{ group.deal_price }}) - Transfer ke auditor ({{player.bribe}}) - Denda ({{ player.penalty }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+</p>
+{% endif %}
+
+{% if group.audit == False or group.category == "Barang Mewah" %}
+<p>
+    Tidak ditemukan ketidaksesuaian dalam laporan Anda.
+    Total Tarif yang berlaku adalah = {{ player.tariff }} poin.<br>
+    {{ if player.role == "Importir" }}
+    Pendapatan akhir Anda adalah Nilai Barang ({{ player.goods_value }}) - Biaya tarif ({{ player.tariff }}) - Kesepakatan transfer ({{ group.deal_price }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+    {{ if player.role == "Petugas Pajak" }}
+    Pendapatan akhir Anda adalah Gaji ({{C.SALARY}}) + Kesepakatan transfer ({{ group.deal_price }}) - Transfer ke auditor ({{player.bribe}}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+</p>
+{% endif %}
+
+<hr>
+<p>
+    <strong>Jumlah Barang Diimpor:</strong> {{ group.quantity }}<br>
+    <strong>Kategori Barang Impor Dari Petugas: </strong> {{ group.category }}<br>
+    <strong>Total Tarif yang berlaku adalah = {{ player.tariff }}</strong><br>
+    <strong>Denda Saat Ini:</strong> {{ player.penalty }} poin
+</p>
+
+{{ next_button }}
+
+{{ endblock }}

--- a/compound_practice_random_kecil_fixed/Results.html
+++ b/compound_practice_random_kecil_fixed/Results.html
@@ -1,0 +1,42 @@
+{{ block title }}
+    Pengambilan Keputusan (SESI LATIHAN)<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+<p>
+    Kategori apa yang akan Anda berikan kepada barang impor tersebut?
+    {{ formfield 'category' }}
+</p>
+
+Nilai Barang = {{ player.goods_value }} poin<br>
+Tarif barang mewah = (jumlah barang × 3) +(jumlah barang × harga barang (20 poin) × 20%) = {{ player.mewah_tariff }} poin<br>
+Tarif barang biasa = (jumlah barang × 2) +(jumlah barang × harga barang (20 poin) × 15%) = {{ player.biasa_tariff }} poin<br>
+
+{{ if group.deal_price == 0 }}
+<p>
+    Tidak ada negosiasi, sehingga Anda tidak menerima transfer dari importir.
+</p>
+{{ next_button }}
+{{ endif }}
+<br><br>
+
+{{ if group.deal_price > 0 }}
+<p>
+    Anda menyepakati untuk menerima transfer sebesar <strong>{{ group.deal_price }} poin</strong>.
+</p>
+<p>
+    Kegiatan ini memiliki kemungkinan audit 50:50. Jika audit menemukan ketidaksesuaian,
+    denda sebesar <strong>{{ player.potential_penalty }} poin</strong> akan dikenakan pada Anda.
+</p>
+<p>
+    Anda juga berkesempatan memberikan transfer kepada auditor untuk mengurangi risiko audit. Setiap 1 poin yang dikirim petugas ke auditor akan menurunkan peluang audit sebesar 1% dan kemungkinan
+              terendah Anda akan terkena audit adalah 10%.
+</p>
+{{ formfield 'bribe' }}
+{{ next_button }}
+{{ endif }}
+
+<hr>
+
+{{ endblock }}

--- a/compound_practice_random_kecil_fixed/Results2.html
+++ b/compound_practice_random_kecil_fixed/Results2.html
@@ -1,0 +1,12 @@
+{{ block title }}
+    Anda telah menyelesaikan ronde terakhir pada sesi ini (SESI LATIHAN)
+{{ endblock }}
+{{ block content }}
+Setelah dilakukan pengacakan, terpilih ronde {{player.random_round}} sebagai ronde pembyaran Anda pada sesi ini. <br>
+Hasil Anda pada ronde tersebut adalah {{player.payment}} poin. Poin ini dikalikan Rp50 rupiah untuk pembayaran eksperimen yaitu {{player.payment}} x 50 + uang kehadiran Rp15000 = {{player.payoff}} <br><br>
+<button>
+    Lanjut
+</button><p></p>
+
+{{ endblock }}
+

--- a/compound_practice_random_kecil_fixed/__init__.py
+++ b/compound_practice_random_kecil_fixed/__init__.py
@@ -1,0 +1,332 @@
+from otree.api import *
+import random
+import math
+
+doc = """
+For oTree beginners, it would be simpler to implement this as a discrete-time game 
+by using multiple rounds, e.g. 10 rounds, where in each round both players can make a new proposal,
+or accept the value from the previous round.
+
+However, the discrete-time version has more limitations
+(fixed communication structure, limited number of iterations).
+
+Also, the continuous-time version works smoother & faster, 
+and is less resource-intensive since it all takes place in 1 page.
+"""
+
+
+class C(BaseConstants):
+    NAME_IN_URL = 'compound_practice_random_kecil_fixed'
+    PLAYERS_PER_GROUP = 2
+    NUM_ROUNDS = 2
+
+    # Keep the roles, profits, salary, officer cost
+    SALARY = 500
+    OFFICER_COST = 10
+    SELLER_ROLE = 'Importir'
+    BUYER_ROLE = 'Petugas Pajak'
+
+    # Parameters for quantity and product price
+    FIXED_PRICE = 20
+    MEAN_QUANTITY = 32
+    SD_QUANTITY = 6.4
+
+    # Specific tariff (ST) for Mewah vs. Biasa
+    ST_MEWAH = 3
+    ST_BIASA = 2
+
+
+
+class Subsession(BaseSubsession):
+    pass
+
+
+def creating_session(subsession: Subsession):
+    # BUGFIX: in oTree 5 the grouping hook must be a MODULE-LEVEL function named
+    # `creating_session` taking the subsession as its argument. The previous app
+    # defined it as a method `Subsession.creating_session(self)`, which oTree 5
+    # never calls, so no re-grouping ran and partners stayed fixed across rounds.
+    #
+    # Re-shuffle into new random groups EVERY round (called once per round at
+    # session creation). `fixed_id_in_group=True` keeps each participant's
+    # id_in_group -- and therefore their role (Importir / Petugas Pajak) -- fixed,
+    # so only the partner changes, not the role. (Random re-matching; a repeat
+    # pairing by chance is possible and acceptable -- this is not perfect-stranger
+    # matching.)
+    subsession.group_randomly(fixed_id_in_group=True)
+
+class Group(BaseGroup):
+    deal_price = models.IntegerField()
+    is_finished = models.BooleanField(initial=False)
+    chance = models.IntegerField(initial=0)
+    chance2 = models.FloatField(initial=0)
+    # New field to store the random quantity (so it remains consistent if page is refreshed)
+    quantity = models.IntegerField(initial=0)
+    category = models.StringField()
+    bribe_chance = models.FloatField(initial=0)
+    audit = models.BooleanField()
+
+
+class Player(BasePlayer):
+    usia = models.IntegerField(label="Usia Anda (Tahun):",
+                               min=18, max=60)
+    gender = models.StringField(widget=widgets.RadioSelect,
+                                label="Jenis kelamin:",
+                                choices=["Pria", "Wanita"])
+    edukasi = models.StringField(widget=widgets.RadioSelect,
+                                 label="Tingkat Pendidikan yang sedang atau telah Anda tempuh:",
+                                 choices=["Diploma 3 (D3)",
+                                          "Sarjana/Diploma 4 (S1/D4)",
+                                          "Magister (S2)",
+                                          "Doktoral (S3)",
+                                          ])
+    provinsi = models.IntegerField(label="Tempat asal Provinsi",
+                                   choices=[[1, 'ACEH'], [2, 'BALI'], [3, 'BANTEN'], [4, 'BENGKULU'],
+                                            [5, 'DI YOGYAKARTA'], [6, 'DKI JAKARTA'],
+                                            [7, 'GORONTALO'], [8, 'JAMBI'], [9, 'JAWA BARAT'], [10, 'JAWA TENGAH'],
+                                            [11, 'JAWA TIMUR'],
+                                            [12, 'KALIMANTAN BARAT'], [13, 'KALIMANTAN SELATAN'],
+                                            [14, 'KALIMANTAN TENGAH'],
+                                            [15, 'KALIMANTAN TIMUR'], [16, 'KALIMANTAN UTARA'],
+                                            [17, 'KEPULAUAN BANGKA BELITUNG'],
+                                            [18, 'KEPULAUAN RIAU'], [19, 'LAMPUNG'], [20, 'MALUKU'],
+                                            [21, 'MALUKU UTARA'], [22, 'NUSA TENGGARA BARAT'],
+                                            [23, 'NUSA TENGGARA TIMUR'], [24, 'PAPUA'], [25, 'PAPUA BARAT'],
+                                            [26, 'PAPUA BARAT DAYA'],
+                                            [27, 'PAPUA PEGUNUNGAN'], [28, 'PAPUA SELATAN'], [29, 'PAPUA TENGAH'],
+                                            [30, 'RIAU'], [31, 'SULAWESI BARAT'],
+                                            [32, 'SULAWESI SELATAN'], [33, 'SULAWESI TENGAH'],
+                                            [34, 'SULAWESI TENGGARA'], [35, 'SULAWESI UTARA'],
+                                            [36, 'SUMATERA BARAT'], [37, 'SUMATERA SELATAN'], [38, 'SUMATERA UTARA']])
+    fakultas = models.StringField()
+    amount_proposed = models.IntegerField()
+    amount_accepted = models.IntegerField()
+    mewah_tariff = models.FloatField()
+    biasa_tariff = models.FloatField()
+    goods_value = models.FloatField()
+    pay = models.FloatField(initial=0)
+    tariff = models.FloatField(initial=0)
+    chance = models.IntegerField(initial=0)
+    bribe = models.IntegerField(blank=True, label="Iuran kepada auditor")
+    category = models.PositiveIntegerField(
+        choices=[[0, 'Barang Mewah'], [1, 'Barang Biasa']],
+        widget=widgets.RadioSelectHorizontal,
+        label="katagori barang"
+    )
+    payment = models.FloatField(initial=0)
+    penalty = models.FloatField(initial=0)
+    potential_penalty = models.FloatField(initial=0)
+    random_round = models.PositiveIntegerField()
+    rekening = models.StringField(label="Nomor Rekening")
+    tipe_pembayaran = models.StringField(widget=widgets.RadioSelect,
+                                label="Tipe Pembayaran",
+                                choices=["Gopay", "Ovo","Shopee","BNI","Mandiri","BCA","BRI"])
+    tipe_pembayaran_lain = models.StringField(
+        blank=True,
+        label="Jika lainnya, sebutkan:"
+    )
+    nomor_hp = models.StringField(label="Telepon")
+
+
+class Bargain(Page):
+    timeout_seconds = 180
+
+    @staticmethod
+    def vars_for_template(player: Player):
+        """Randomize quantity (once) and show possible tariffs for Barang Mewah & Biasa."""
+        group = player.group
+
+        # Randomize quantity only once per group (if not yet set).
+        if group.quantity == 0:
+            q = max(1, int(random.gauss(C.MEAN_QUANTITY, C.SD_QUANTITY)))
+            group.quantity = q
+
+        # Compute possible tariffs for demonstration (e.g. to show on the template).
+        player.goods_value = group.quantity * C.FIXED_PRICE
+
+        # Compound tariff for Mewah
+        player.mewah_tariff = (group.quantity*C.ST_MEWAH) + (group.quantity * C.FIXED_PRICE * 0.20)
+        # Compound tariff for Biasa
+        player.biasa_tariff = (group.quantity*C.ST_BIASA) + (group.quantity * C.FIXED_PRICE * 0.15)
+
+        return dict(
+            other_role=player.get_others_in_group()[0].role,
+            quantity=group.quantity,
+            mewah_tariff=int(player.mewah_tariff),
+            biasa_tariff=int(player.biasa_tariff),
+        )
+
+    @staticmethod
+    def js_vars(player: Player):
+        return dict(my_id=player.id_in_group)
+
+    @staticmethod
+    def live_method(player: Player, data):
+        group = player.group
+        [other] = player.get_others_in_group()
+
+        if 'amount' in data:
+            try:
+                amount = int(data['amount'])
+            except Exception:
+                print('Invalid message received', data)
+                return
+            if data['type'] == 'accept':
+                if amount == other.amount_proposed:
+                    player.amount_accepted = amount
+                    group.deal_price = amount
+                    group.is_finished = True
+                    return {0: dict(finished=True)}
+            if data['type'] == 'propose':
+                player.amount_proposed = amount
+            if data['type'] == 'reject':
+                if amount == other.amount_proposed:
+                    player.amount_accepted = 0
+                    group.deal_price = 0
+                    group.is_finished = True
+                    return {0: dict(finished=True)}
+
+        proposals = []
+        for p in [player, other]:
+            amount_proposed = p.field_maybe_none('amount_proposed')
+            if amount_proposed is not None:
+                proposals.append([p.id_in_group, amount_proposed])
+        return {0: dict(proposals=proposals)}
+
+    @staticmethod
+    def error_message(player: Player, values):
+        group = player.group
+        if not group.is_finished:
+            return "Game not finished yet"
+
+    @staticmethod
+    def is_displayed(player: Player):
+        """Skip this page if a deal has already been made"""
+        group = player.group
+        deal_price = group.field_maybe_none('deal_price')
+        return deal_price is None
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        """Use the new tariff scheme to compute player's payoff."""
+        group = player.group
+        if player.role == "Importir":
+            player.potential_penalty = 1.5 * player.mewah_tariff
+        else:
+            player.potential_penalty = 0.5 * C.SALARY
+        if timeout_happened:
+            player.amount_accepted = 0
+            player.amount_proposed = 0
+            group.deal_price = 0
+
+        # Compute tariff based on whether a 'deal_price' (bribe) was reached.
+        # If deal_price == 0 => treat as Barang Mewah
+        # If deal_price > 0 => treat as Barang Biasa
+        goods_value = group.quantity * C.FIXED_PRICE
+
+
+        if group.deal_price == 0:
+            # Barang Mewah
+            player.tariff = player.mewah_tariff
+            if player.role == "Importir":
+                player.pay = goods_value - player.tariff
+            else:
+                player.pay = C.SALARY
+        else:
+            # Barang Biasa
+            player.tariff = player.biasa_tariff
+            if player.role == "Importir":
+                # Importer pays the bribe plus the tariff
+                player.pay = goods_value - player.tariff - group.deal_price
+            else:
+                # Officer receives the bribe, minus cost
+                player.pay = C.SALARY + group.deal_price
+
+
+class Results(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.role == "Petugas Pajak"
+
+    form_model = 'player'
+    form_fields = ['bribe', 'category']
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        group = player.group
+        if player.category == 0:
+            group.category = "Barang Mewah"
+        else:
+            group.category = "Barang Biasa"
+        players = group.get_players()
+        bribe = player.field_maybe_none('bribe')
+        group.chance = random.randint(1,200)
+        if bribe is None:
+            player.bribe = 0
+        else:
+            if player.role == "Petugas Pajak":
+                player.pay = C.SALARY + group.deal_price - player.bribe
+            if player.bribe > 80:
+                bribe = 80
+            player.chance = bribe
+        group.bribe_chance = player.chance
+
+
+
+class ResultsWaitPage(WaitPage):
+    pass
+
+
+class Investigation(Page):
+    @staticmethod
+    def vars_for_template(player: Player):
+        group = player.group
+        if group.category == "Barang Biasa":
+            player.tariff = player.biasa_tariff
+            group.chance2 = 100 - group.bribe_chance
+            if group.chance < group.chance2:
+                group.audit = True
+                if player.role == "Importir":
+                    player.penalty = 1.5 * player.tariff
+                else:
+                    player.penalty = 0.5 * C.SALARY
+            else:
+                group.audit = False
+                player.penalty = 0
+        else:
+            player.tariff = player.mewah_tariff
+            player.penalty = 0
+            group.audit = False
+        player.payment = player.pay - player.penalty
+        if player.payment < 0:
+            player.payment = 0
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        import random
+        participant = player.participant
+
+        # if it's the last round
+        if player.round_number == C.NUM_ROUNDS:
+            random_round = random.randint(1, C.NUM_ROUNDS)
+            participant.selected_round = random_round
+            player.random_round = random_round
+            player_in_selected_round = player.in_round(random_round)
+            player.payoff = (player.payment*50) + 15000
+
+class MyWaitPage(WaitPage):
+    wait_for_all_groups = True
+
+class Instructions(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.round_number == 1
+
+class demographic(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.round_number == 1
+    form_model = 'player'
+    form_fields = ['provinsi', 'usia', 'gender', 'fakultas', 'edukasi']
+
+page_sequence = [Instructions, demographic, ResultsWaitPage, Bargain, Results, ResultsWaitPage, Investigation, MyWaitPage]

--- a/compound_practice_random_kecil_fixed/demographic.html
+++ b/compound_practice_random_kecil_fixed/demographic.html
@@ -1,0 +1,11 @@
+{{ block title }}
+    Survey
+{{ endblock }}
+{{ block content }}
+    <h3>Mohon isi kuesioner ini dengan sebenar-benarnya; termasuk platform pembayaran online.
+        Eksperimenter tidak akan membagikan data yang Anda berikan kepada siapapun</h3><br>
+    {{ formfields }}
+<br><p></p>
+<button class="otree-btn-next btn btn-primary next-button otree-next-button">Lanjut</button>
+
+{{ endblock }}

--- a/compound_practice_random_sedang_fixed/Bargain.html
+++ b/compound_practice_random_sedang_fixed/Bargain.html
@@ -1,0 +1,185 @@
+{{ block title }}
+Pelaporan Pajak (SESI LATIHAN)<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+
+<!-- Minimal CSS styling for a cleaner look -->
+<style>
+    .section-box {
+        margin-bottom: 1.5em;
+        padding: 1em;
+        background-color: #f9f9f9;
+        border: 1px solid #ddd;
+        border-radius: 5px;
+        line-height: 1.5;
+    }
+    .section-box h2 {
+        margin-top: 0;
+    }
+    .section-box ul {
+        margin-top: 0.5em;
+        margin-bottom: 0.5em;
+        padding-left: 1.5em;
+    }
+    .negotiation-table {
+        border-collapse: collapse;
+        width: 100%;
+        margin-top: 1em;
+    }
+    .negotiation-table th,
+    .negotiation-table td {
+        border: 1px solid #ccc;
+        padding: 0.5em;
+    }
+    .debug-section {
+        margin-top: 1em;
+        padding: 0.5em;
+        background-color: #fefefe;
+        border: 1px dashed #ccc;
+    }
+</style>
+
+{{ if player.role == "Importir" }}
+<div class="section-box">
+    <h2>Importir</h2>
+    <p>
+        Anda merupakan importir barang mewah yang berpotensi meraih keuntungan.
+        Saat ini, Anda mengimpor sejumlah <strong>{{ quantity }}</strong> unit.
+        Nilai barang = jumlah barang × harga (20 poin), sehingga nilai barang Anda adalah <strong>{{ player.goods_value }}</strong> poin.
+    </p>
+    <p>
+        Apabila barang dikategorikan sebagai <em>Barang Mewah</em>, tarif dihitung sebagai:
+        <br>
+        (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).
+        <br>
+        Nilai tarif barang mewah adalah <strong>{{ mewah_tariff }}</strong> poin.
+    </p>
+    <p>
+        Anda dapat bernegosiasi dengan petugas pajak untuk mengubah kategori menjadi <em>Barang Biasa</em>, sehingga tarif dihitung sebagai:
+        <br>
+        (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).
+        <br>
+        Nilai tarif barang biasa adalah <strong>{{ biasa_tariff }}</strong> poin.
+        Hasil kesepakatan Anda dengan petugas pajak tidak menjamin kategori akan berubah karena keputusan akhir ada di petugas pajak.
+    </p>
+    <p>
+        Jika terjadi audit (50:50) dan ditemukan ketidaksesuaian, maka denda sebesar 1.5 × nilai tarif akan dikenakan ke Anda.
+    </p>
+</div>
+{{ endif }}
+
+{{ if player.role == "Petugas Pajak" }}
+<div class="section-box">
+    <h2>Petugas Pajak</h2>
+    <p>
+        Anda merupakan petugas pajak impor dengan gaji <strong>{{C.SALARY}}</strong> poin.
+        Anda menentukan kategori barang (Mewah/Barang Biasa) dan menghitung tarif berikut:
+    </p>
+    <ul>
+        <li><em>Barang Mewah</em>: (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).</li>
+        <li><em>Barang Biasa</em>: (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).</li>
+    </ul>
+    <p>
+        Saat ini, jumlah barang mewah yang diimpor adalah sebanyak <strong>{{ quantity }}</strong> unit dengan nilai sebesar <strong>{{ player.goods_value }}</strong> poin.
+        Apabila barang dikategorikan sebagai <em>Barang Mewah</em>, maka nilai tarif = <strong>{{ mewah_tariff }}</strong> poin.
+        Apabila barang dikategorikan sebagai <em>Barang Biasa</em>, maka nilai tarif = <strong>{{ biasa_tariff }}</strong> poin.
+    </p>
+    <p>
+        Importir memiliki potensi keuntungan dan dapat menawarkan transfer kepada Anda agar barang dikategorikan sebagai Barang Biasa.
+        Namun, keputusan akhir ada di tangan Anda.
+        Jika terjadi audit (50:50) dan ditemukan ketidaksesuaian, maka denda sebesar 50% gaji akan dikenakan ke Anda.
+    </p>
+</div>
+{{ endif }}
+
+<p>
+    Silakan bernegosiasi dengan {{ other_role }} mengenai besaran transfer. Jika tidak tercapai kesepakatan,
+    tarif impor akan dikenakan penuh sesuai kategori awal, tanpa transfer.
+</p>
+
+<table class="negotiation-table">
+    <tr>
+        <th>Proposal Transfer Anda</th>
+        <td id="my-proposal">(none)</td>
+        <td>
+            <input type="number" id="my_offer">
+            <button type="button" onclick="sendOffer()" id="btn-offer">Ajukan Transfer</button>
+        </td>
+    </tr>
+
+    <tr>
+        <th>Proposal Transfer {{ other_role }}</th>
+        <td id="other-proposal">(none)</td>
+{{ if player.role == "Petugas Pajak" }}
+        <td>
+            <button type="button" id="btn-accept" onclick="sendAccept(this)" style="display: none">Terima</button>
+        </td>
+        <td>
+            <button type="button" id="btn-reject" onclick="sendReject(this)" style="display: none">Tolak</button>
+        </td>
+    </tr>
+{{ endif }}
+</table>
+
+<h4>Chat</h4>
+{{ chat nickname=player.role }}
+
+<!-- No changes to JavaScript below -->
+<script>
+    let my_offer = document.getElementById('my_offer');
+    let btnAccept = document.getElementById('btn-accept');
+    let btnReject = document.getElementById('btn-reject');
+    let msgOtherProposal = document.getElementById('other-proposal');
+    let msgMyProposal = document.getElementById('my-proposal');
+
+    let otherProposal;
+
+    my_offer.addEventListener("keydown", function (event) {
+        if (event.key === "Enter") {
+            sendOffer();
+        }
+    });
+
+    function sendOffer() {
+        liveSend({'type': 'propose', 'amount': my_offer.value})
+        my_offer.value = '';
+    }
+
+    function sendAccept() {
+        liveSend({'type': 'accept', 'amount': otherProposal})
+    }
+
+    function sendReject() {
+        liveSend({'type': 'reject', 'amount': otherProposal})
+    }
+
+    function cu(amount) {
+        return `${amount} poin`;
+    }
+
+    function liveRecv(data) {
+        if ('proposals' in data) {
+            for (let [id_in_group, proposal] of data.proposals) {
+                if (id_in_group === js_vars.my_id) {
+                    msgMyProposal.innerHTML = cu(proposal);
+                } else {
+                    msgOtherProposal.innerHTML = cu(proposal);
+                    otherProposal = proposal;
+                    btnAccept.style.display = 'block';
+                    btnReject.style.display = 'block';
+                }
+            }
+        }
+        if ('finished' in data) {
+            document.getElementById('form').submit();
+        }
+    }
+
+    window.addEventListener('DOMContentLoaded', (event) => {
+        liveSend({});
+    });
+</script>
+
+{{ endblock }}

--- a/compound_practice_random_sedang_fixed/Instructions.html
+++ b/compound_practice_random_sedang_fixed/Instructions.html
@@ -1,0 +1,378 @@
+{% extends "global/Page.html" %}
+{% block content %}
+
+<form id="instructionsForm" method="post" style="margin: 0; padding: 0;">
+
+  <!-- PAGE 1: General Instructions -->
+  <div id="page1" style="display: block;">
+    <div style="
+      max-width: 800px;
+      margin: 40px auto;
+      padding: 20px;
+      border: 2px solid #000;
+      background-color: #fff;
+      line-height: 1.5;
+      text-align: justify;
+    ">
+      <h2 style="text-align: center; margin-top: 0;">INSTRUKSI</h2>
+
+      <p>
+        Selamat datang dan terima kasih telah bersedia untuk mengikuti eksperimen ini.
+        Mohon baca instruksi ini dengan seksama agar Anda memahami apa yang harus Anda lakukan di dalam eksperimen ini.
+        Eksperimen ini memberikan Anda kesempatan untuk memperoleh uang tunai yang akan dibayarkan segera setelah Anda menyelesaikan rangkaian eksperimen ini.
+        Besaran uang yang akan Anda peroleh bergantung pada apa yang Anda dan rekan Anda lakukan di dalam eksperimen ini.
+        Oleh karenanya, mohon untuk serius dalam menyelesaikannya sesuai dengan preferensi Anda.
+      </p>
+
+      <p>
+        Eksperimen ini bertujuan untuk memahami perilaku dan interaksi yang terjadi di dalam sebuah pelaporan dan pengecekan barang impor.
+        Anda akan ditempatkan secara acak apakah menjadi seorang importir barang atau petugas yang melakukan cek atas barang impor sepanjang eksperimen ini.
+        Jumlah importir dan petugas akan sama di satu sesi eksperimen. Anda akan menghadapi 20 ronde dengan tipikal yang sama sesuai peran Anda masing-masing:
+        seorang importir atau petugas. Peserta akan berinteraksi satu sama lain dalam 3 menit per rondenya.
+        Anda bisa berkomunikasi dengan lawan main di setiap ronde melalui kolom chat yang tersedia. Seluruh peserta akan menyelesaikan eksperimen ini secara bersamaan.
+        Selain itu, Anda juga akan diminta untuk mengisi kuesioner singkat setelah Anda menyelesaikan eksperimen ini.
+      </p>
+
+      <p>
+        Eksperimen ini telah mendapatkan persetujuan dari Komisi Etik Direktorat Penelitian UGM.
+        Lembar persetujuan terinformasi telah dikirim bersamaan dengan email undangan dan telah Anda setujui. Anda dapat melihat kembali lembar tersebut di <a href="
+        https://drive.google.com/file/d/1eS9WdjCHcOSkZf494_D67Rge-8DPnUFr/view?usp=sharing" target="_blank">https://drive.google.com/file/d/1eS9WdjCHcOSkZf494_D67Rge-8DPnUFr/view?usp=sharing</a>
+      </p>
+
+      <p>
+        Silakan klik tombol <strong>LANJUT</strong> di bawah ini untuk mendapatkan acakan peran di dalam eksperimen ini.
+      </p>
+
+      <div style="text-align: center;">
+        <button type="button" onclick="showPage(2)">LANJUT</button>
+      </div>
+
+      <p style="text-align: center; margin-top: 30px;">
+        <em>Tim Peneliti</em>
+      </p>
+    </div>
+  </div>
+
+
+  <!-- PAGE 2: Role-Specific Instructions with lined tables -->
+  <div id="page2" style="display: none;">
+    {% if player.role == "Importir" %}
+      <!-- IMPORTIR -->
+      <div style="
+        max-width: 800px;
+        margin: 40px auto;
+        padding: 20px;
+        border: 2px solid #000;
+        background-color: #fff;
+        line-height: 1.5;
+        text-align: justify;
+      ">
+
+        <h2 style="margin-top: 0;">
+          **** Instruksi untuk Importir ****
+        </h2>
+        <h3>ANDA MENDAPATKAN PERAN SEBAGAI IMPORTIR BARANG</h3>
+
+        <h4>Eksperimen</h4>
+        <p>
+          Sebagai seorang importir, Anda melakukan impor barang mewah dengan nilai tertentu di mana barang impor tersebut akan dikenai tarif impor barang mewah.
+          Besaran tarif impor barang mewah bergantung dari jumlah dan harga barang yang Anda impor.
+          Di setiap ronde, Anda harus melaporkan nilai dari barang yang Anda impor kepada petugas untuk dihitung nilai tarif impornya yang akan menjadi tanggungan Anda.
+          Anda dapat berkomunikasi kepada petugas melalui kolom chat.
+          Akan terdapat auditor yang secara acak mengecek laporan pajak Anda.
+          Berikut adalah penjelasan umum eksperimen untuk Anda sebagai importir barang:
+        </p>
+
+        <table style="width: 100%; border-collapse: collapse; border: 1px solid black;">
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top; width: 30%;">
+              Kategori Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Terdapat dua kategori barang impor dalam eksperimen ini: Barang Mewah dan Barang Biasa.
+              Kedua barang berbeda dalam pengenaan tarif pajaknya.
+              Namun, Anda hanya akan mengimpor barang mewah di dalam eksperimen ini.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Harga dan Kuantitas Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Kuantitas barang yang Anda impor (<em>Q</em>) diambil secara acak dari distribusi normal dengan rata-rata {{C.MEAN_QUANTITY}} dan deviasi standar {{C.SD_QUANTITY}}.
+              Harga barang mewah yang Anda impor (<em>P</em>) akan selalu tetap untuk seluruh ronde yaitu {{C.FIXED_PRICE}} poin.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Nilai Tarif Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Eksperimen ini menggunakan tarif compound dengan penghitungan
+              <code>T = (Q * s) + (Q * P * t)</code>, di mana s adalah tarif spesifik yang dikenakan per unit barang
+              diimpor dan t adalah tarif ad valorem dalam bentuk persen dari total nilai impor.
+              Pengenaan tarif impor T didasarkan atas klasifikasi barang impor sebagai berikut:
+
+              <ul>
+                <li><em>Barang Mewah</em>: (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).</li>
+                <li><em>Barang Biasa</em>: (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).</li>
+              </ul>
+              Dalam hal ini, barang impor akan dikenakan pajak yang lebih murah ketika dikategorikan sebagai barang biasa daripada barang mewah.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Interaksi dengan Petugas Pajak
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan dihubungkan dengan <strong> satu petugas pajak yang berbeda </strong> sepanjang eksperimen ini yang tugasnya adalah memastikan pelaporan barang yang Anda impor.
+              Anda dan petugas pajak akan berada di halaman yang sama pada saat pelaporan barang impor Anda.
+              Petugas pajak yang akan membersamai Anda ditentukan secara acak sebelum ronde pertama dimulai dan bersifat anonim.
+              Anda dapat berkomunikasi kepada petugas melalui kolom chat dan Anda dapat mengirimkan transfer kepada petugas pajak untuk mengubah kategori barang impor Anda.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Proses Audit atas Laporan Petugas Pajak
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Petugas pajak mengirimkan laporan pajak Anda ke otoritas pajak. Petugas pajak bisa saja melaporkan jenis
+              barang yang berbeda dari yang didiskusikan sebelumnya. Auditor (komputer) akan mengumpulkan seluruh laporan
+              pajak yang dikirimkan oleh petugas pajak untuk diaudit. Laporan pajak Anda memiliki kemungkinan untuk menjadi
+              sampel audit sebesar 50%. Jika hasil audit menunjukkan Anda tidak melaporkan sesuai dengan nilai impor sesungguhnya,
+              maka Anda akan menerima denda. Petugas dapat menurunkan peluang laporan pajak Anda diaudit dengan mengirimkan transfer
+              ke Auditor. Setiap 1 poin yang dikirim petugas ke auditor akan menurunkan peluang audit sebesar 0.5% dan kemungkinan
+              terendah Anda akan terkena audit adalah 10%.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Denda atas Laporan yang Tidak Sesuai
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Jika hasil audit menunjukkan laporan yang tidak sesuai, maka denda yang Anda terima adalah sebesar 150% dari nilai tarif yang Anda bayarkan.
+              Denda ini di luar nilai tarif yang telah Anda bayarkan berdasarkan laporan yang Anda berikan.
+              Transfer Anda kepada petugas dalam proses negosiasi akan hangus dan tidak dikembalikan kepada Anda.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Payoff di Setiap Ronde
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Basis payoff Anda adalah nilai barang impor yang Anda lakukan dan proses yang terjadi setelahnya.
+              Payoff dari setiap ronde akan diinformasikan setelah suatu ronde berakhir dengan penghitungan sebagai berikut:
+              <br><em>Nilai barang yang diimpor – pajak impor (berdasarkan laporan Anda) – nilai transaksi negosiasi (jika ada) – denda (jika ada)</em>.
+              <br>Jika payoff terhitung Anda adalah negatif, maka payoff Anda di ronde tersebut adalah nol.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Catatan Penting
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda dan petugas akan berada pada halaman yang sama di setiap ronde pada saat proses pelaporan.
+              Anda (tidak) akan diinformasikan lawan main (petugas pajak) di setiap ronde.
+              Informasi tersebut berupa kode partisipan masing-masing partisipan mengacu pada nomor meja.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Durasi Eksperimen
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Kami mengestimasi penyelesaian rangkaian eksperimen ini selama lebih-kurang 90 menit.
+              Kami harap Anda menyelesaikan eksperimen ini berdasarkan preferensi Anda sendiri karena akan menentukan pembayaran yang Anda peroleh, termasuk proses negosiasi yang Anda lakukan kepada petugas.
+              Anda dapat menghubungi kami setiap saat selama eksperimen jika ada hal-hal yang perlu Anda tanyakan mengenai prosedur eksperimen ini.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Pembayaran
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan mendapatkan dua bentuk pembayaran dari eksperimen yang Anda telah selesaikan: uang kehadiran sebesar Rp15.000 dan payoff dari salah satu ronde eksperimen.
+              Satu ronde dari seluruh ronde di masing-masing eksperimen akan diambil secara acak melalui distribusi seragam untuk menjadi basis pembayaran Anda.
+              Pembayaran (poin) yang Anda peroleh dari masing-masing eksperimen tersebut dikalikan dengan Rp50 untuk menjadi pembayaran final.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Langkah Selanjutnya
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan menuju ke survei pra-eksperimen setelah ini jika Anda telah mengerti dan setuju untuk mengikuti eksperimen ini.
+              Klik tanda ‘SETUJU’ di bawah ini.
+            </td>
+          </tr>
+        </table>
+
+        <div style="text-align: center; margin-top: 20px;">
+          <button>Setuju</button>
+        </div>
+      </div>
+
+
+    {% else %}
+      <!-- PETUGAS -->
+      <div style="
+        max-width: 800px;
+        margin: 40px auto;
+        padding: 20px;
+        border: 2px solid #000;
+        background-color: #fff;
+        line-height: 1.5;
+        text-align: justify;
+      ">
+
+        <h2 style="margin-top: 0;">
+          **** Instruksi untuk Petugas ****
+        </h2>
+        <h3>ANDA MENDAPATKAN PERAN SEBAGAI PETUGAS</h3>
+
+        <h4>Eksperimen</h4>
+        <p>
+          Sebagai seorang petugas, Anda diminta untuk melakukan pengecekan atas laporan impor barang mewah yang masuk oleh importir.
+          Anda dapat berkomunikasi dengan importir untuk mengubah kategori barang impor dari barang mewah menjadi barang biasa, atau mempertahankan kategori barang mewah tersebut.
+          Setelah komunikasi selesai, Anda akan diminta menentukan kategori barang impor tersebut dan meneruskannya ke otoritas pajak.
+          Akan terdapat auditor yang secara acak mengecek laporan pajak importir dan laporan kategori Anda.
+          Berikut adalah penjelasan umum eksperimen untuk Anda sebagai petugas pengecekan barang impor yang masuk:
+        </p>
+
+        <table style="width: 100%; border-collapse: collapse; border: 1px solid black;">
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top; width: 30%;">
+              Kategori Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Terdapat dua kategori barang impor dalam eksperimen ini: Barang Mewah dan Barang Biasa.
+              Kedua barang berbeda dalam pengenaan tarif pajaknya.
+              Namun, importir hanya akan mengimpor barang mewah di dalam eksperimen ini.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Harga dan Kuantitas Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Kuantitas barang yang Anda impor (<em>Q</em>) diambil secara acak dari distribusi normal dengan rata-rata {{C.MEAN_QUANTITY}} dan deviasi standar {{C.SD_QUANTITY}}.
+              Harga barang mewah yang Anda impor (<em>P</em>) akan selalu tetap untuk seluruh ronde yaitu {{C.FIXED_PRICE}} poin.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Nilai Tarif Barang Impor
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Eksperimen ini menggunakan tarif compound dengan penghitungan
+              <code>T = (Q * s) + (Q * P * t)</code>, di mana s adalah tarif spesifik yang dikenakan per unit barang
+              diimpor dan t adalah tarif ad valorem dalam bentuk persen dari total nilai impor.
+              Pengenaan tarif impor T didasarkan atas klasifikasi barang impor sebagai berikut:
+
+              <ul>
+                <li><em>Barang Mewah</em>: (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).</li>
+                <li><em>Barang Biasa</em>: (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).</li>
+              </ul>
+              Dalam hal ini, barang impor akan dikenakan pajak yang lebih murah ketika dikategorikan sebagai barang biasa daripada barang mewah.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Interaksi dengan Importir
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan dihubungkan dengan <strong> satu importir yang berbeda </strong> sepanjang eksperimen ini dan Anda dan importir akan berada di halaman yang sama pada saat pelaporan barang impor Anda.
+Importir yang akan membersamai Anda ditentukan secara acak sebelum ronde pertama dimulai dan bersifat anonim.
+Anda dapat berkomunikasi kepada importir melalui kolom chat.
+Anda dapat menerima, menolak, atau mengusulkan nominal transfer dari importir untuk mengubah kategori barang impor.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Proses Audit atas Laporan
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Petugas pajak mengirimkan laporan pajak Anda ke otoritas pajak. Petugas pajak bisa saja melaporkan jenis
+              barang yang berbeda dari yang didiskusikan sebelumnya. Auditor (komputer) akan mengumpulkan seluruh laporan
+              pajak yang dikirimkan oleh petugas pajak untuk diaudit. Laporan pajak Anda memiliki kemungkinan untuk menjadi
+              sampel audit sebesar 50%. Jika hasil audit menunjukkan Anda tidak melaporkan sesuai dengan nilai impor sesungguhnya,
+              maka Anda akan menerima denda. Petugas dapat menurunkan peluang laporan pajak Anda diaudit dengan mengirimkan transfer
+              ke Auditor. Setiap 1 poin yang dikirim petugas ke auditor akan menurunkan peluang audit sebesar 0.5% dan kemungkinan
+              terendah Anda akan terkena audit adalah 10%.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Denda atas Laporan yang Tidak Sesuai
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Jika laporan yang Anda teruskan menjadi sampel audit dan ditemukan ketidaksesuaian dari aslinya oleh Auditor,
+              maka Anda akan didenda sebesar upah menjadi petugas dan bagian yang Anda terima dari importir.
+              Dengan kata lain, Anda tidak mendapatkan apa-apa dari ronde tersebut dari denda yang ada.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Payoff di Setiap Ronde
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Payoff yang Anda terima berbasis pada upah menjadi petugas ({{C.SALARY}} poin) dan tambahan dari hasil negosiasi dengan importir dan Auditor.
+              Berikut penghitungan payoff Anda di setiap ronde:
+              <br><em>Upah petugas + poin transaksi (jika bekerja sama dalam pemalsuan laporan) – denda (jika terbukti melakukan pelanggaran)</em>.
+              <br>Namun payoff Anda akan hangus jika Auditor menemukan pemalsuan laporan dan Anda terlibat di dalamnya.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Durasi Eksperimen
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Kami mengestimasi penyelesaian rangkaian eksperimen ini selama lebih-kurang 90 menit.
+              Kami harap Anda menyelesaikan eksperimen ini berdasarkan preferensi Anda sendiri karena akan menentukan pembayaran yang Anda peroleh,
+              termasuk proses negosiasi yang Anda lakukan kepada petugas.
+              Anda dapat menghubungi kami setiap saat selama eksperimen jika ada hal-hal yang perlu Anda tanyakan mengenai prosedur eksperimen ini.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Pembayaran
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan mendapatkan dua bentuk pembayaran dari eksperimen yang Anda telah selesaikan: uang kehadiran sebesar Rp15.000 dan payoff dari salah satu ronde eksperimen.
+              Satu ronde dari seluruh ronde di masing-masing eksperimen akan diambil secara acak melalui distribusi seragam untuk menjadi basis pembayaran Anda.
+              Pembayaran (poin) yang Anda peroleh dari masing-masing eksperimen tersebut dikalikan dengan Rp50 untuk menjadi pembayaran final.
+            </td>
+          </tr>
+          <tr>
+            <td style="border: 1px solid black; font-weight: bold; vertical-align: top;">
+              Langkah Selanjutnya
+            </td>
+            <td style="border: 1px solid black; vertical-align: top;">
+              Anda akan menuju ke survei pra-eksperimen setelah ini jika Anda telah mengerti dan setuju untuk mengikuti eksperimen ini.
+              Klik tanda ‘SETUJU’ di bawah ini.
+            </td>
+          </tr>
+        </table>
+
+      <div style="text-align: center; margin-top: 20px;">
+          <button>Setuju</button>
+      </div>
+    {% endif %}
+
+  </div>
+
+</form>
+
+<script>
+  function showPage(pageNumber) {
+    if (pageNumber === 2) {
+      document.getElementById("page1").style.display = "none";
+      document.getElementById("page2").style.display = "block";
+    }
+  }
+  function submitForm() {
+    document.getElementById("instructionsForm").submit();
+  }
+</script>
+
+{% endblock %}

--- a/compound_practice_random_sedang_fixed/Investigation.html
+++ b/compound_practice_random_sedang_fixed/Investigation.html
@@ -1,0 +1,44 @@
+{{ block title }}
+   Hasil (SESI LATIHAN)<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+
+{% if group.audit == True and group.category == "Barang Biasa" %}
+<p>
+    Hasil audit menemukan ketidaksesuaian pada pelaporan kategori.
+    Denda sebesar <strong>{{ player.penalty }} poin</strong> diberlakukan, <br>
+    {{ if player.role == "Importir" }}
+    Pendapatan akhir Anda adalah = Nilai Barang ({{ player.goods_value }}) - Biaya tarif ({{ player.tariff }}) - Kesepakatan transfer ({{ group.deal_price }}) - Denda ({{ player.penalty }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+    {{ if player.role == "Petugas Pajak" }}
+    Pendapatan akhir Anda adalah Gaji ({{C.SALARY}}) + Kesepakatan transfer ({{ group.deal_price }}) - Transfer ke auditor ({{player.bribe}}) - Denda ({{ player.penalty }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+</p>
+{% endif %}
+
+{% if group.audit == False or group.category == "Barang Mewah" %}
+<p>
+    Tidak ditemukan ketidaksesuaian dalam laporan Anda.
+    Total Tarif yang berlaku adalah = {{ player.tariff }} poin.<br>
+    {{ if player.role == "Importir" }}
+    Pendapatan akhir Anda adalah Nilai Barang ({{ player.goods_value }}) - Biaya tarif ({{ player.tariff }}) - Kesepakatan transfer ({{ group.deal_price }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+    {{ if player.role == "Petugas Pajak" }}
+    Pendapatan akhir Anda adalah Gaji ({{C.SALARY}}) + Kesepakatan transfer ({{ group.deal_price }}) - Transfer ke auditor ({{player.bribe}}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+</p>
+{% endif %}
+
+<hr>
+<p>
+    <strong>Jumlah Barang Diimpor:</strong> {{ group.quantity }}<br>
+    <strong>Kategori Barang Impor Dari Petugas: </strong> {{ group.category }}<br>
+    <strong>Total Tarif yang berlaku adalah = {{ player.tariff }}</strong><br>
+    <strong>Denda Saat Ini:</strong> {{ player.penalty }} poin
+</p>
+
+{{ next_button }}
+
+{{ endblock }}

--- a/compound_practice_random_sedang_fixed/Results.html
+++ b/compound_practice_random_sedang_fixed/Results.html
@@ -1,0 +1,42 @@
+{{ block title }}
+    Pengambilan Keputusan (SESI LATIHAN)<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+<p>
+    Kategori apa yang akan Anda berikan kepada barang impor tersebut?
+    {{ formfield 'category' }}
+</p>
+
+Nilai Barang = {{ player.goods_value }} poin<br>
+Tarif barang mewah = (jumlah barang × 3) +(jumlah barang × harga barang (20 poin) × 20%) = {{ player.mewah_tariff }} poin<br>
+Tarif barang biasa = (jumlah barang × 2) +(jumlah barang × harga barang (20 poin) × 15%) = {{ player.biasa_tariff }} poin<br>
+
+{{ if group.deal_price == 0 }}
+<p>
+    Tidak ada negosiasi, sehingga Anda tidak menerima transfer dari importir.
+</p>
+{{ next_button }}
+{{ endif }}
+<br><br>
+
+{{ if group.deal_price > 0 }}
+<p>
+    Anda menyepakati untuk menerima transfer sebesar <strong>{{ group.deal_price }} poin</strong>.
+</p>
+<p>
+    Kegiatan ini memiliki kemungkinan audit 50:50. Jika audit menemukan ketidaksesuaian,
+    denda sebesar <strong>{{ player.potential_penalty }} poin</strong> akan dikenakan pada Anda.
+</p>
+<p>
+    Anda juga berkesempatan memberikan transfer kepada auditor untuk mengurangi risiko audit. Setiap 1 poin yang dikirim petugas ke auditor akan menurunkan peluang audit sebesar 0.5% dan kemungkinan
+              terendah Anda akan terkena audit adalah 10%.
+</p>
+{{ formfield 'bribe' }}
+{{ next_button }}
+{{ endif }}
+
+<hr>
+
+{{ endblock }}

--- a/compound_practice_random_sedang_fixed/Results2.html
+++ b/compound_practice_random_sedang_fixed/Results2.html
@@ -1,0 +1,12 @@
+{{ block title }}
+    Anda telah menyelesaikan ronde terakhir pada sesi ini (SESI LATIHAN)
+{{ endblock }}
+{{ block content }}
+Setelah dilakukan pengacakan, terpilih ronde {{player.random_round}} sebagai ronde pembyaran Anda pada sesi ini. <br>
+Hasil Anda pada ronde tersebut adalah {{player.payment}} poin. Poin ini dikalikan Rp50 rupiah untuk pembayaran eksperimen yaitu {{player.payment}} x 50 + uang kehadiran Rp15000 = {{player.payoff}} <br><br>
+<button>
+    Lanjut
+</button><p></p>
+
+{{ endblock }}
+

--- a/compound_practice_random_sedang_fixed/__init__.py
+++ b/compound_practice_random_sedang_fixed/__init__.py
@@ -1,0 +1,332 @@
+from otree.api import *
+import random
+import math
+
+doc = """
+For oTree beginners, it would be simpler to implement this as a discrete-time game 
+by using multiple rounds, e.g. 10 rounds, where in each round both players can make a new proposal,
+or accept the value from the previous round.
+
+However, the discrete-time version has more limitations
+(fixed communication structure, limited number of iterations).
+
+Also, the continuous-time version works smoother & faster, 
+and is less resource-intensive since it all takes place in 1 page.
+"""
+
+
+class C(BaseConstants):
+    NAME_IN_URL = 'compound_practice_random_sedang_fixed'
+    PLAYERS_PER_GROUP = 2
+    NUM_ROUNDS = 2
+
+    # Keep the roles, profits, salary, officer cost
+    SALARY = 1250
+    OFFICER_COST = 10
+    SELLER_ROLE = 'Importir'
+    BUYER_ROLE = 'Petugas Pajak'
+
+    # Parameters for quantity and product price
+    FIXED_PRICE = 20
+    MEAN_QUANTITY = 80
+    SD_QUANTITY = 16
+
+    # Specific tariff (ST) for Mewah vs. Biasa
+    ST_MEWAH = 3
+    ST_BIASA = 2
+
+
+
+class Subsession(BaseSubsession):
+    pass
+
+
+def creating_session(subsession: Subsession):
+    # BUGFIX: in oTree 5 the grouping hook must be a MODULE-LEVEL function named
+    # `creating_session` taking the subsession as its argument. The previous app
+    # defined it as a method `Subsession.creating_session(self)`, which oTree 5
+    # never calls, so no re-grouping ran and partners stayed fixed across rounds.
+    #
+    # Re-shuffle into new random groups EVERY round (called once per round at
+    # session creation). `fixed_id_in_group=True` keeps each participant's
+    # id_in_group -- and therefore their role (Importir / Petugas Pajak) -- fixed,
+    # so only the partner changes, not the role. (Random re-matching; a repeat
+    # pairing by chance is possible and acceptable -- this is not perfect-stranger
+    # matching.)
+    subsession.group_randomly(fixed_id_in_group=True)
+
+class Group(BaseGroup):
+    deal_price = models.IntegerField()
+    is_finished = models.BooleanField(initial=False)
+    chance = models.IntegerField(initial=0)
+    chance2 = models.FloatField(initial=0)
+    # New field to store the random quantity (so it remains consistent if page is refreshed)
+    quantity = models.IntegerField(initial=0)
+    category = models.StringField()
+    bribe_chance = models.FloatField(initial=0)
+    audit = models.BooleanField()
+
+
+class Player(BasePlayer):
+    usia = models.IntegerField(label="Usia Anda (Tahun):",
+                               min=18, max=60)
+    gender = models.StringField(widget=widgets.RadioSelect,
+                                label="Jenis kelamin:",
+                                choices=["Pria", "Wanita"])
+    edukasi = models.StringField(widget=widgets.RadioSelect,
+                                 label="Tingkat Pendidikan yang sedang atau telah Anda tempuh:",
+                                 choices=["Diploma 3 (D3)",
+                                          "Sarjana/Diploma 4 (S1/D4)",
+                                          "Magister (S2)",
+                                          "Doktoral (S3)",
+                                          ])
+    provinsi = models.IntegerField(label="Tempat asal Provinsi",
+                                   choices=[[1, 'ACEH'], [2, 'BALI'], [3, 'BANTEN'], [4, 'BENGKULU'],
+                                            [5, 'DI YOGYAKARTA'], [6, 'DKI JAKARTA'],
+                                            [7, 'GORONTALO'], [8, 'JAMBI'], [9, 'JAWA BARAT'], [10, 'JAWA TENGAH'],
+                                            [11, 'JAWA TIMUR'],
+                                            [12, 'KALIMANTAN BARAT'], [13, 'KALIMANTAN SELATAN'],
+                                            [14, 'KALIMANTAN TENGAH'],
+                                            [15, 'KALIMANTAN TIMUR'], [16, 'KALIMANTAN UTARA'],
+                                            [17, 'KEPULAUAN BANGKA BELITUNG'],
+                                            [18, 'KEPULAUAN RIAU'], [19, 'LAMPUNG'], [20, 'MALUKU'],
+                                            [21, 'MALUKU UTARA'], [22, 'NUSA TENGGARA BARAT'],
+                                            [23, 'NUSA TENGGARA TIMUR'], [24, 'PAPUA'], [25, 'PAPUA BARAT'],
+                                            [26, 'PAPUA BARAT DAYA'],
+                                            [27, 'PAPUA PEGUNUNGAN'], [28, 'PAPUA SELATAN'], [29, 'PAPUA TENGAH'],
+                                            [30, 'RIAU'], [31, 'SULAWESI BARAT'],
+                                            [32, 'SULAWESI SELATAN'], [33, 'SULAWESI TENGAH'],
+                                            [34, 'SULAWESI TENGGARA'], [35, 'SULAWESI UTARA'],
+                                            [36, 'SUMATERA BARAT'], [37, 'SUMATERA SELATAN'], [38, 'SUMATERA UTARA']])
+    fakultas = models.StringField()
+    amount_proposed = models.IntegerField()
+    amount_accepted = models.IntegerField()
+    mewah_tariff = models.FloatField()
+    biasa_tariff = models.FloatField()
+    goods_value = models.FloatField()
+    pay = models.FloatField(initial=0)
+    tariff = models.FloatField(initial=0)
+    chance = models.IntegerField(initial=0)
+    bribe = models.IntegerField(blank=True, label="Iuran kepada auditor")
+    category = models.PositiveIntegerField(
+        choices=[[0, 'Barang Mewah'], [1, 'Barang Biasa']],
+        widget=widgets.RadioSelectHorizontal,
+        label="katagori barang"
+    )
+    payment = models.FloatField(initial=0)
+    penalty = models.FloatField(initial=0)
+    potential_penalty = models.FloatField(initial=0)
+    random_round = models.PositiveIntegerField()
+    rekening = models.StringField(label="Nomor Rekening")
+    tipe_pembayaran = models.StringField(widget=widgets.RadioSelect,
+                                label="Tipe Pembayaran",
+                                choices=["Gopay", "Ovo","Shopee","BNI","Mandiri","BCA","BRI"])
+    tipe_pembayaran_lain = models.StringField(
+        blank=True,
+        label="Jika lainnya, sebutkan:"
+    )
+    nomor_hp = models.StringField(label="Telepon")
+
+
+class Bargain(Page):
+    timeout_seconds = 180
+
+    @staticmethod
+    def vars_for_template(player: Player):
+        """Randomize quantity (once) and show possible tariffs for Barang Mewah & Biasa."""
+        group = player.group
+
+        # Randomize quantity only once per group (if not yet set).
+        if group.quantity == 0:
+            q = max(1, int(random.gauss(C.MEAN_QUANTITY, C.SD_QUANTITY)))
+            group.quantity = q
+
+        # Compute possible tariffs for demonstration (e.g. to show on the template).
+        player.goods_value = group.quantity * C.FIXED_PRICE
+
+        # Compound tariff for Mewah
+        player.mewah_tariff = (group.quantity*C.ST_MEWAH) + (group.quantity * C.FIXED_PRICE * 0.20)
+        # Compound tariff for Biasa
+        player.biasa_tariff = (group.quantity*C.ST_BIASA) + (group.quantity * C.FIXED_PRICE * 0.15)
+
+        return dict(
+            other_role=player.get_others_in_group()[0].role,
+            quantity=group.quantity,
+            mewah_tariff=int(player.mewah_tariff),
+            biasa_tariff=int(player.biasa_tariff),
+        )
+
+    @staticmethod
+    def js_vars(player: Player):
+        return dict(my_id=player.id_in_group)
+
+    @staticmethod
+    def live_method(player: Player, data):
+        group = player.group
+        [other] = player.get_others_in_group()
+
+        if 'amount' in data:
+            try:
+                amount = int(data['amount'])
+            except Exception:
+                print('Invalid message received', data)
+                return
+            if data['type'] == 'accept':
+                if amount == other.amount_proposed:
+                    player.amount_accepted = amount
+                    group.deal_price = amount
+                    group.is_finished = True
+                    return {0: dict(finished=True)}
+            if data['type'] == 'propose':
+                player.amount_proposed = amount
+            if data['type'] == 'reject':
+                if amount == other.amount_proposed:
+                    player.amount_accepted = 0
+                    group.deal_price = 0
+                    group.is_finished = True
+                    return {0: dict(finished=True)}
+
+        proposals = []
+        for p in [player, other]:
+            amount_proposed = p.field_maybe_none('amount_proposed')
+            if amount_proposed is not None:
+                proposals.append([p.id_in_group, amount_proposed])
+        return {0: dict(proposals=proposals)}
+
+    @staticmethod
+    def error_message(player: Player, values):
+        group = player.group
+        if not group.is_finished:
+            return "Game not finished yet"
+
+    @staticmethod
+    def is_displayed(player: Player):
+        """Skip this page if a deal has already been made"""
+        group = player.group
+        deal_price = group.field_maybe_none('deal_price')
+        return deal_price is None
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        """Use the new tariff scheme to compute player's payoff."""
+        group = player.group
+        if player.role == "Importir":
+            player.potential_penalty = 1.5 * player.mewah_tariff
+        else:
+            player.potential_penalty = 0.5 * C.SALARY
+        if timeout_happened:
+            player.amount_accepted = 0
+            player.amount_proposed = 0
+            group.deal_price = 0
+
+        # Compute tariff based on whether a 'deal_price' (bribe) was reached.
+        # If deal_price == 0 => treat as Barang Mewah
+        # If deal_price > 0 => treat as Barang Biasa
+        goods_value = group.quantity * C.FIXED_PRICE
+
+
+        if group.deal_price == 0:
+            # Barang Mewah
+            player.tariff = player.mewah_tariff
+            if player.role == "Importir":
+                player.pay = goods_value - player.tariff
+            else:
+                player.pay = C.SALARY
+        else:
+            # Barang Biasa
+            player.tariff = player.biasa_tariff
+            if player.role == "Importir":
+                # Importer pays the bribe plus the tariff
+                player.pay = goods_value - player.tariff - group.deal_price
+            else:
+                # Officer receives the bribe, minus cost
+                player.pay = C.SALARY + group.deal_price
+
+
+class Results(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.role == "Petugas Pajak"
+
+    form_model = 'player'
+    form_fields = ['bribe', 'category']
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        group = player.group
+        if player.category == 0:
+            group.category = "Barang Mewah"
+        else:
+            group.category = "Barang Biasa"
+        players = group.get_players()
+        bribe = player.field_maybe_none('bribe')
+        group.chance = random.randint(1,200)
+        if bribe is None:
+            player.bribe = 0
+        else:
+            if player.role == "Petugas Pajak":
+                player.pay = C.SALARY + group.deal_price - player.bribe
+            if player.bribe > 80:
+                bribe = 80
+            player.chance = bribe
+        group.bribe_chance = player.chance
+
+
+
+class ResultsWaitPage(WaitPage):
+    pass
+
+
+class Investigation(Page):
+    @staticmethod
+    def vars_for_template(player: Player):
+        group = player.group
+        if group.category == "Barang Biasa":
+            player.tariff = player.biasa_tariff
+            group.chance2 = 100 - group.bribe_chance
+            if group.chance < group.chance2:
+                group.audit = True
+                if player.role == "Importir":
+                    player.penalty = 1.5 * player.tariff
+                else:
+                    player.penalty = 0.5 * C.SALARY
+            else:
+                group.audit = False
+                player.penalty = 0
+        else:
+            player.tariff = player.mewah_tariff
+            player.penalty = 0
+            group.audit = False
+        player.payment = player.pay - player.penalty
+        if player.payment < 0:
+            player.payment = 0
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        import random
+        participant = player.participant
+
+        # if it's the last round
+        if player.round_number == C.NUM_ROUNDS:
+            random_round = random.randint(1, C.NUM_ROUNDS)
+            participant.selected_round = random_round
+            player.random_round = random_round
+            player_in_selected_round = player.in_round(random_round)
+            player.payoff = (player.payment*50) + 15000
+
+class MyWaitPage(WaitPage):
+    wait_for_all_groups = True
+
+class Instructions(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.round_number == 1
+
+class demographic(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.round_number == 1
+    form_model = 'player'
+    form_fields = ['provinsi', 'usia', 'gender', 'fakultas', 'edukasi']
+
+page_sequence = [Instructions, demographic, ResultsWaitPage, Bargain, Results, ResultsWaitPage, Investigation, MyWaitPage]

--- a/compound_practice_random_sedang_fixed/demographic.html
+++ b/compound_practice_random_sedang_fixed/demographic.html
@@ -1,0 +1,11 @@
+{{ block title }}
+    Survey
+{{ endblock }}
+{{ block content }}
+    <h3>Mohon isi kuesioner ini dengan sebenar-benarnya; termasuk platform pembayaran online.
+        Eksperimenter tidak akan membagikan data yang Anda berikan kepada siapapun</h3><br>
+    {{ formfields }}
+<br><p></p>
+<button class="otree-btn-next btn btn-primary next-button otree-next-button">Lanjut</button>
+
+{{ endblock }}

--- a/compound_sedang_random_fixed/Bargain.html
+++ b/compound_sedang_random_fixed/Bargain.html
@@ -1,0 +1,185 @@
+{{ block title }}
+Pelaporan Pajak<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+
+<!-- Minimal CSS styling for a cleaner look -->
+<style>
+    .section-box {
+        margin-bottom: 1.5em;
+        padding: 1em;
+        background-color: #f9f9f9;
+        border: 1px solid #ddd;
+        border-radius: 5px;
+        line-height: 1.5;
+    }
+    .section-box h2 {
+        margin-top: 0;
+    }
+    .section-box ul {
+        margin-top: 0.5em;
+        margin-bottom: 0.5em;
+        padding-left: 1.5em;
+    }
+    .negotiation-table {
+        border-collapse: collapse;
+        width: 100%;
+        margin-top: 1em;
+    }
+    .negotiation-table th,
+    .negotiation-table td {
+        border: 1px solid #ccc;
+        padding: 0.5em;
+    }
+    .debug-section {
+        margin-top: 1em;
+        padding: 0.5em;
+        background-color: #fefefe;
+        border: 1px dashed #ccc;
+    }
+</style>
+
+{{ if player.role == "Importir" }}
+<div class="section-box">
+    <h2>Importir</h2>
+    <p>
+        Anda merupakan importir barang mewah yang berpotensi meraih keuntungan.
+        Saat ini, Anda mengimpor sejumlah <strong>{{ quantity }}</strong> unit.
+        Nilai barang = jumlah barang × harga (20 poin), sehingga nilai barang Anda adalah <strong>{{ player.goods_value }}</strong> poin.
+    </p>
+    <p>
+        Apabila barang dikategorikan sebagai <em>Barang Mewah</em>, tarif dihitung sebagai:
+        <br>
+        (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).
+        <br>
+        Nilai tarif barang mewah adalah <strong>{{ mewah_tariff }}</strong> poin.
+    </p>
+    <p>
+        Anda dapat bernegosiasi dengan petugas pajak untuk mengubah kategori menjadi <em>Barang Biasa</em>, sehingga tarif dihitung sebagai:
+        <br>
+        (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).
+        <br>
+        Nilai tarif barang biasa adalah <strong>{{ biasa_tariff }}</strong> poin.
+        Hasil kesepakatan Anda dengan petugas pajak tidak menjamin kategori akan berubah karena keputusan akhir ada di petugas pajak.
+    </p>
+    <p>
+        Jika terjadi audit (50:50) dan ditemukan ketidaksesuaian, maka denda sebesar 1.5 × nilai tarif akan dikenakan ke Anda.
+    </p>
+</div>
+{{ endif }}
+
+{{ if player.role == "Petugas Pajak" }}
+<div class="section-box">
+    <h2>Petugas Pajak</h2>
+    <p>
+        Anda merupakan petugas pajak impor dengan gaji <strong>{{C.SALARY}}</strong> poin.
+        Anda menentukan kategori barang (Mewah/Barang Biasa) dan menghitung tarif berikut:
+    </p>
+    <ul>
+        <li><em>Barang Mewah</em>: (jumlah barang × 3) + (jumlah barang × harga barang (20 poin) × 20%).</li>
+        <li><em>Barang Biasa</em>: (jumlah barang × 2) + (jumlah barang × harga barang (20 poin) × 15%).</li>
+    </ul>
+    <p>
+        Saat ini, jumlah barang mewah yang diimpor adalah sebanyak <strong>{{ quantity }}</strong> unit dengan nilai sebesar <strong>{{ player.goods_value }}</strong> poin.
+        Apabila barang dikategorikan sebagai <em>Barang Mewah</em>, maka nilai tarif = <strong>{{ mewah_tariff }}</strong> poin.
+        Apabila barang dikategorikan sebagai <em>Barang Biasa</em>, maka nilai tarif = <strong>{{ biasa_tariff }}</strong> poin.
+    </p>
+    <p>
+        Importir memiliki potensi keuntungan dan dapat menawarkan transfer kepada Anda agar barang dikategorikan sebagai Barang Biasa.
+        Namun, keputusan akhir ada di tangan Anda.
+        Jika terjadi audit (50:50) dan ditemukan ketidaksesuaian, maka denda sebesar 50% gaji akan dikenakan ke Anda.
+    </p>
+</div>
+{{ endif }}
+
+<p>
+    Silakan bernegosiasi dengan {{ other_role }} mengenai besaran transfer. Jika tidak tercapai kesepakatan,
+    tarif impor akan dikenakan penuh sesuai kategori awal, tanpa transfer.
+</p>
+
+<table class="negotiation-table">
+    <tr>
+        <th>Proposal Transfer Anda</th>
+        <td id="my-proposal">(none)</td>
+        <td>
+            <input type="number" id="my_offer">
+            <button type="button" onclick="sendOffer()" id="btn-offer">Ajukan Transfer</button>
+        </td>
+    </tr>
+
+    <tr>
+        <th>Proposal Transfer {{ other_role }}</th>
+        <td id="other-proposal">(none)</td>
+{{ if player.role == "Petugas Pajak" }}
+        <td>
+            <button type="button" id="btn-accept" onclick="sendAccept(this)" style="display: none">Terima</button>
+        </td>
+        <td>
+            <button type="button" id="btn-reject" onclick="sendReject(this)" style="display: none">Tolak</button>
+        </td>
+    </tr>
+{{ endif }}
+</table>
+
+<h4>Chat</h4>
+{{ chat nickname=player.role }}
+
+<!-- No changes to JavaScript below -->
+<script>
+    let my_offer = document.getElementById('my_offer');
+    let btnAccept = document.getElementById('btn-accept');
+    let btnReject = document.getElementById('btn-reject');
+    let msgOtherProposal = document.getElementById('other-proposal');
+    let msgMyProposal = document.getElementById('my-proposal');
+
+    let otherProposal;
+
+    my_offer.addEventListener("keydown", function (event) {
+        if (event.key === "Enter") {
+            sendOffer();
+        }
+    });
+
+    function sendOffer() {
+        liveSend({'type': 'propose', 'amount': my_offer.value})
+        my_offer.value = '';
+    }
+
+    function sendAccept() {
+        liveSend({'type': 'accept', 'amount': otherProposal})
+    }
+
+    function sendReject() {
+        liveSend({'type': 'reject', 'amount': otherProposal})
+    }
+
+    function cu(amount) {
+        return `${amount} poin`;
+    }
+
+    function liveRecv(data) {
+        if ('proposals' in data) {
+            for (let [id_in_group, proposal] of data.proposals) {
+                if (id_in_group === js_vars.my_id) {
+                    msgMyProposal.innerHTML = cu(proposal);
+                } else {
+                    msgOtherProposal.innerHTML = cu(proposal);
+                    otherProposal = proposal;
+                    btnAccept.style.display = 'block';
+                    btnReject.style.display = 'block';
+                }
+            }
+        }
+        if ('finished' in data) {
+            document.getElementById('form').submit();
+        }
+    }
+
+    window.addEventListener('DOMContentLoaded', (event) => {
+        liveSend({});
+    });
+</script>
+
+{{ endblock }}

--- a/compound_sedang_random_fixed/Instructions.html
+++ b/compound_sedang_random_fixed/Instructions.html
@@ -1,0 +1,11 @@
+{{ block title }}
+    Sesi Dimulai
+{{ endblock }}
+{{ block content }}
+    Anda akan memasuki sesi yang sebenarnya, keputusan Anda akan berdampak kepada pendapatan Anda di akhir sesi.
+        Anda akan terhubung dengan petugas atau importir yang sama selama sesi eksperimen. Selamat menjalankan eksperimen.
+
+{{ next_button }}
+
+
+{{ endblock }}

--- a/compound_sedang_random_fixed/Investigation.html
+++ b/compound_sedang_random_fixed/Investigation.html
@@ -1,0 +1,44 @@
+{{ block title }}
+   Hasil<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+
+{% if group.audit == True and group.category == "Barang Biasa" %}
+<p>
+    Hasil audit menemukan ketidaksesuaian pada pelaporan kategori.
+    Denda sebesar <strong>{{ player.penalty }} poin</strong> diberlakukan, <br>
+    {{ if player.role == "Importir" }}
+    Pendapatan akhir Anda adalah = Nilai Barang ({{ player.goods_value }}) - Biaya tarif ({{ player.tariff }}) - Kesepakatan transfer ({{ group.deal_price }}) - Denda ({{ player.penalty }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+    {{ if player.role == "Petugas Pajak" }}
+    Pendapatan akhir Anda adalah Gaji ({{C.SALARY}}) + Kesepakatan transfer ({{ group.deal_price }}) - Transfer ke auditor ({{player.bribe}}) - Denda ({{ player.penalty }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+</p>
+{% endif %}
+
+{% if group.audit == False or group.category == "Barang Mewah" %}
+<p>
+    Tidak ditemukan ketidaksesuaian dalam laporan Anda.
+    Total Tarif yang berlaku adalah = {{ player.tariff }} poin.<br>
+    {{ if player.role == "Importir" }}
+    Pendapatan akhir Anda adalah Nilai Barang ({{ player.goods_value }}) - Biaya tarif ({{ player.tariff }}) - Kesepakatan transfer ({{ group.deal_price }}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+    {{ if player.role == "Petugas Pajak" }}
+    Pendapatan akhir Anda adalah Gaji ({{C.SALARY}}) + Kesepakatan transfer ({{ group.deal_price }}) - Transfer ke auditor ({{player.bribe}}) = <strong>{{ player.payment }} poin</strong>.
+    {{ endif }}
+</p>
+{% endif %}
+
+<hr>
+<p>
+    <strong>Jumlah Barang Diimpor:</strong> {{ group.quantity }}<br>
+    <strong>Kategori Barang Impor Dari Petugas: </strong> {{ group.category }}<br>
+    <strong>Total Tarif yang berlaku adalah = {{ player.tariff }}</strong><br>
+    <strong>Denda Saat Ini:</strong> {{ player.penalty }} poin
+</p>
+
+{{ next_button }}
+
+{{ endblock }}

--- a/compound_sedang_random_fixed/Results.html
+++ b/compound_sedang_random_fixed/Results.html
@@ -1,0 +1,42 @@
+{{ block title }}
+    Pengambilan Keputusan<br>
+Ronde {{player.round_number}}
+{{ endblock }}
+
+{{ block content }}
+<p>
+    Kategori apa yang akan Anda berikan kepada barang impor tersebut?
+    {{ formfield 'category' }}
+</p>
+
+Nilai Barang = {{ player.goods_value }} poin<br>
+Tarif barang mewah = (jumlah barang × 3) +(jumlah barang × harga barang (20 poin) × 20%) = {{ player.mewah_tariff }} poin<br>
+Tarif barang biasa = (jumlah barang × 2) +(jumlah barang × harga barang (20 poin) × 15%) = {{ player.biasa_tariff }} poin<br>
+
+{{ if group.deal_price == 0 }}
+<p>
+    Tidak ada negosiasi, sehingga Anda tidak menerima transfer dari importir.
+</p>
+{{ next_button }}
+{{ endif }}
+<br><br>
+
+{{ if group.deal_price > 0 }}
+<p>
+    Anda menyepakati untuk menerima transfer sebesar <strong>{{ group.deal_price }} poin</strong>.
+</p>
+<p>
+    Kegiatan ini memiliki kemungkinan audit 50:50. Jika audit menemukan ketidaksesuaian,
+    denda sebesar <strong>{{ player.potential_penalty }} poin</strong> akan dikenakan pada pendapatan importir dan petugas pajak.
+</p>
+<p>
+    Anda juga berkesempatan memberikan transfer kepada auditor untuk mengurangi risiko audit. Setiap 1 poin yang dikirim petugas ke auditor akan menurunkan peluang audit sebesar 0.5% dan kemungkinan
+              terendah Anda akan terkena audit adalah 10%.
+</p>
+{{ formfield 'bribe' }}
+{{ next_button }}
+{{ endif }}
+
+<hr>
+
+{{ endblock }}

--- a/compound_sedang_random_fixed/Results2.html
+++ b/compound_sedang_random_fixed/Results2.html
@@ -1,0 +1,12 @@
+{{ block title }}
+    Anda telah menyelesaikan ronde terakhir pada sesi ini
+{{ endblock }}
+{{ block content }}
+Setelah dilakukan pengacakan, terpilih ronde {{selected_round}} sebagai ronde pembyaran Anda pada sesi ini. <br>
+Hasil Anda pada ronde tersebut adalah {{pay_in_selected_round}} poin. Poin ini dikalikan Rp50 rupiah untuk pembayaran eksperimen yaitu {{pay_in_selected_round}} x 50 + uang kehadiran Rp15000 = {{final_payoff}} <br><br>
+<button>
+    Lanjut
+</button><p></p>
+
+{{ endblock }}
+

--- a/compound_sedang_random_fixed/__init__.py
+++ b/compound_sedang_random_fixed/__init__.py
@@ -1,0 +1,323 @@
+from otree.api import *
+import random
+import math
+
+doc = """
+For oTree beginners, it would be simpler to implement this as a discrete-time game 
+by using multiple rounds, e.g. 10 rounds, where in each round both players can make a new proposal,
+or accept the value from the previous round.
+
+However, the discrete-time version has more limitations
+(fixed communication structure, limited number of iterations).
+
+Also, the continuous-time version works smoother & faster, 
+and is less resource-intensive since it all takes place in 1 page.
+"""
+
+
+class C(BaseConstants):
+    NAME_IN_URL = 'compound_sedang_random_fixed'
+    PLAYERS_PER_GROUP = 2
+    NUM_ROUNDS = 20
+
+    # Keep the roles, profits, salary, officer cost
+    SALARY = 1250
+    OFFICER_COST = 10
+    SELLER_ROLE = 'Importir'
+    BUYER_ROLE = 'Petugas Pajak'
+
+    # Parameters for quantity and product price
+    FIXED_PRICE = 20
+    MEAN_QUANTITY = 80
+    SD_QUANTITY = 16
+
+    # Specific tariff (ST) for Mewah vs. Biasa
+    ST_MEWAH = 3
+    ST_BIASA = 2
+
+
+
+class Subsession(BaseSubsession):
+    pass
+
+
+def creating_session(subsession: Subsession):
+    # BUGFIX: in oTree 5 the grouping hook must be a MODULE-LEVEL function named
+    # `creating_session` taking the subsession as its argument. The previous app
+    # defined it as a method `Subsession.creating_session(self)`, which oTree 5
+    # never calls, so no re-grouping ran and partners stayed fixed across rounds.
+    #
+    # Re-shuffle into new random groups EVERY round (called once per round at
+    # session creation). `fixed_id_in_group=True` keeps each participant's
+    # id_in_group — and therefore their role (Importir / Petugas Pajak) — fixed,
+    # so only the partner changes, not the role. (Random re-matching; a repeat
+    # pairing by chance is possible and acceptable — this is not perfect-stranger
+    # matching.)
+    subsession.group_randomly(fixed_id_in_group=True)
+
+class Group(BaseGroup):
+    deal_price = models.IntegerField()
+    is_finished = models.BooleanField(initial=False)
+    chance = models.IntegerField(initial=0)
+    chance2 = models.FloatField(initial=0)
+    # New field to store the random quantity (so it remains consistent if page is refreshed)
+    quantity = models.IntegerField(initial=0)
+    category = models.StringField()
+    bribe_chance = models.FloatField(initial=0)
+    audit = models.BooleanField()
+
+
+class Player(BasePlayer):
+    amount_proposed = models.IntegerField()
+    amount_accepted = models.IntegerField()
+    mewah_tariff = models.FloatField()
+    biasa_tariff = models.FloatField()
+    goods_value = models.FloatField()
+    pay = models.FloatField(initial=0)
+    tariff = models.FloatField(initial=0)
+    chance = models.IntegerField(initial=0)
+    bribe = models.IntegerField(blank=True, label="Iuran kepada auditor")
+    category = models.PositiveIntegerField(
+        choices=[[0, 'Barang Mewah'], [1, 'Barang Biasa']],
+        widget=widgets.RadioSelectHorizontal,
+        label="katagori barang"
+    )
+    payment = models.FloatField(initial=0)
+    penalty = models.FloatField(initial=0)
+    potential_penalty = models.FloatField(initial=0)
+    random_round = models.PositiveIntegerField()
+    rekening = models.StringField(label="Nomor Rekening")
+    tipe_pembayaran = models.StringField(widget=widgets.RadioSelect,
+                                label="Tipe Pembayaran",
+                                choices=["Gopay", "Ovo","Shopee","BNI","Mandiri","BCA","BRI"])
+    tipe_pembayaran_lain = models.StringField(
+        blank=True,
+        label="Jika lainnya, sebutkan:"
+    )
+    nomor_hp = models.StringField(label="Telepon")
+
+
+class Bargain(Page):
+    timeout_seconds = 180
+
+    @staticmethod
+    def vars_for_template(player: Player):
+        """Randomize quantity (once) and show possible tariffs for Barang Mewah & Biasa."""
+        group = player.group
+
+        # Randomize quantity only once per group (if not yet set).
+        if group.quantity == 0:
+            q = max(1, int(random.gauss(C.MEAN_QUANTITY, C.SD_QUANTITY)))
+            group.quantity = q
+
+        # Compute possible tariffs for demonstration (e.g. to show on the template).
+        player.goods_value = group.quantity * C.FIXED_PRICE
+
+        # Compound tariff for Mewah
+        player.mewah_tariff = (group.quantity*C.ST_MEWAH) + (group.quantity * C.FIXED_PRICE * 0.20)
+        # Compound tariff for Biasa
+        player.biasa_tariff = (group.quantity*C.ST_BIASA) + (group.quantity * C.FIXED_PRICE * 0.15)
+
+        return dict(
+            other_role=player.get_others_in_group()[0].role,
+            quantity=group.quantity,
+            mewah_tariff=int(player.mewah_tariff),
+            biasa_tariff=int(player.biasa_tariff),
+        )
+
+    @staticmethod
+    def js_vars(player: Player):
+        return dict(my_id=player.id_in_group)
+
+    @staticmethod
+    def live_method(player: Player, data):
+        group = player.group
+        [other] = player.get_others_in_group()
+
+        if 'amount' in data:
+            try:
+                amount = int(data['amount'])
+            except Exception:
+                print('Invalid message received', data)
+                return
+            if data['type'] == 'accept':
+                if amount == other.amount_proposed:
+                    player.amount_accepted = amount
+                    group.deal_price = amount
+                    group.is_finished = True
+                    return {0: dict(finished=True)}
+            if data['type'] == 'propose':
+                player.amount_proposed = amount
+            if data['type'] == 'reject':
+                if amount == other.amount_proposed:
+                    player.amount_accepted = 0
+                    group.deal_price = 0
+                    group.is_finished = True
+                    return {0: dict(finished=True)}
+
+        proposals = []
+        for p in [player, other]:
+            amount_proposed = p.field_maybe_none('amount_proposed')
+            if amount_proposed is not None:
+                proposals.append([p.id_in_group, amount_proposed])
+        return {0: dict(proposals=proposals)}
+
+    @staticmethod
+    def error_message(player: Player, values):
+        group = player.group
+        if not group.is_finished:
+            return "Game not finished yet"
+
+    @staticmethod
+    def is_displayed(player: Player):
+        """Skip this page if a deal has already been made"""
+        group = player.group
+        deal_price = group.field_maybe_none('deal_price')
+        return deal_price is None
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        """Use the new tariff scheme to compute player's payoff."""
+        group = player.group
+        if player.role == "Importir":
+            player.potential_penalty = 1.5 * player.mewah_tariff
+        else:
+            player.potential_penalty = 0.5 * C.SALARY
+        if timeout_happened:
+            player.amount_accepted = 0
+            player.amount_proposed = 0
+            group.deal_price = 0
+
+        # Compute tariff based on whether a 'deal_price' (bribe) was reached.
+        # If deal_price == 0 => treat as Barang Mewah
+        # If deal_price > 0 => treat as Barang Biasa
+        goods_value = group.quantity * C.FIXED_PRICE
+
+
+        if group.deal_price == 0:
+            # Barang Mewah
+            player.tariff = player.mewah_tariff
+            if player.role == "Importir":
+                player.pay = goods_value - player.tariff
+            else:
+                player.pay = C.SALARY
+        else:
+            # Barang Biasa
+            player.tariff = player.biasa_tariff
+            if player.role == "Importir":
+                # Importer pays the bribe plus the tariff
+                player.pay = goods_value - player.tariff - group.deal_price
+            else:
+                # Officer receives the bribe, minus cost
+                player.pay = C.SALARY + group.deal_price
+
+
+class Results(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.role == "Petugas Pajak"
+
+    form_model = 'player'
+    form_fields = ['bribe', 'category']
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        group = player.group
+        if player.category == 0:
+            group.category = "Barang Mewah"
+        else:
+            group.category = "Barang Biasa"
+        players = group.get_players()
+        bribe = player.field_maybe_none('bribe')
+        group.chance = random.randint(1,200)
+        if bribe is None:
+            player.bribe = 0
+        else:
+            if player.role == "Petugas Pajak":
+                player.pay = C.SALARY + group.deal_price - player.bribe
+            if player.bribe > 80:
+                bribe = 80
+            player.chance = bribe
+        group.bribe_chance = player.chance
+
+
+
+class ResultsWaitPage(WaitPage):
+    pass
+
+
+class Investigation(Page):
+    @staticmethod
+    def vars_for_template(player: Player):
+        group = player.group
+        if group.category == "Barang Biasa":
+            player.tariff = player.biasa_tariff
+            group.chance2 = 100 - group.bribe_chance
+            if group.chance < group.chance2:
+                group.audit = True
+                if player.role == "Importir":
+                    player.penalty = 1.5 * player.tariff
+                else:
+                    player.penalty = 0.5 * C.SALARY
+            else:
+                group.audit = False
+                player.penalty = 0
+        else:
+            player.tariff = player.mewah_tariff
+            player.penalty = 0
+            group.audit = False
+        player.payment = player.pay - player.penalty
+        if player.payment < 0:
+            player.payment = 0
+
+    @staticmethod
+    def before_next_page(player: Player, timeout_happened):
+        participant = player.participant
+        # Store the current round's payment in participant vars
+        participant.vars[f'payment_round_{player.round_number}'] = player.payment
+
+        # If it's the last round, select a random round and set the payoff
+        if player.round_number == C.NUM_ROUNDS:
+            random_round = random.randint(1, C.NUM_ROUNDS)
+            participant.selected_round = random_round
+            player.random_round = random_round # This field is on the Player model, useful for display
+
+            # Retrieve the payment from the randomly selected round
+            pay_in_selected_round = participant.vars.get(f'payment_round_{random_round}', 0)
+            player.payoff = (pay_in_selected_round * 50) + 15000
+
+class MyWaitPage(WaitPage):
+    pass
+
+class Instructions(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.round_number == 1
+
+
+class Results2(Page):
+    @staticmethod
+    def is_displayed(player):
+        return player.round_number == C.NUM_ROUNDS
+    
+    @staticmethod
+    def vars_for_template(player: Player):
+        participant = player.participant
+        selected_round = participant.selected_round
+        pay_in_selected_round = participant.vars.get(f'payment_round_{selected_round}', 0)
+
+        return dict(
+            selected_round=selected_round,
+            pay_in_selected_round=int(pay_in_selected_round),
+            final_payoff=int(player.payoff) # Access the payoff already calculated
+        )
+
+class payment(Page):
+    form_model = 'player'
+    form_fields = ['rekening', 'tipe_pembayaran', 'tipe_pembayaran_lain','nomor_hp']
+    @staticmethod
+    def is_displayed(player):
+        return player.round_number == C.NUM_ROUNDS
+
+
+page_sequence = [Instructions, ResultsWaitPage, Bargain, Results, ResultsWaitPage, Investigation, MyWaitPage, Results2,payment]

--- a/compound_sedang_random_fixed/payment.html
+++ b/compound_sedang_random_fixed/payment.html
@@ -1,0 +1,11 @@
+{{ block title }}
+    Survey
+{{ endblock }}
+{{ block content }}
+    <h3>Mohon isi kuesioner ini dengan sebenar-benarnya; untuk platform pembayaran online.
+        Eksperimenter tidak akan membagikan data yang Anda berikan kepada siapapun</h3><br>
+    <a href="https://docs.google.com/forms/d/1b6MVoxYYVEePoQiweADgW44A4m-h6x9ZHCFxzt3NOQ8/viewform?edit_requested=true&pli=1" target="_blank">
+    Klik di sini untuk mengisi kuesioner pembayaran
+</a><br><p></p>
+
+{{ endblock }}

--- a/settings.py
+++ b/settings.py
@@ -17,6 +17,13 @@ SESSION_CONFIGS = [
         num_demo_participants=2,
     ),
     dict(
+        # Fixed-bug version: partners actually re-shuffle each round (practice too).
+        # 4 demo participants so re-matching is observable (2 cannot re-match).
+        name='compound_kecil_random_fixed',
+        app_sequence=['intro', 'compound_practice_random_kecil_fixed', 'compound_kecil_random_fixed'],
+        num_demo_participants=4,
+    ),
+    dict(
         name='compound_sedang',
         app_sequence=['intro', 'compound_practice_sedang', 'compound_sedang'],
         num_demo_participants=2,
@@ -27,6 +34,13 @@ SESSION_CONFIGS = [
         num_demo_participants=2,
     ),
     dict(
+        # Fixed-bug version: partners actually re-shuffle each round (practice too).
+        # 4 demo participants so re-matching is observable (2 cannot re-match).
+        name='compound_sedang_random_fixed',
+        app_sequence=['intro', 'compound_practice_random_sedang_fixed', 'compound_sedang_random_fixed'],
+        num_demo_participants=4,
+    ),
+    dict(
         name='compound_besar',
         app_sequence=['intro', 'compound_practice_besar', 'compound_besar'],
         num_demo_participants=2,
@@ -35,6 +49,13 @@ SESSION_CONFIGS = [
         name='compound_besar_random',
         app_sequence=['intro', 'compound_practice_random_besar', 'compound_besar_random'],
         num_demo_participants=2,
+    ),
+    dict(
+        # Fixed-bug version: partners actually re-shuffle each round (practice too).
+        # 4 demo participants so re-matching is observable (2 cannot re-match).
+        name='compound_besar_random_fixed',
+        app_sequence=['intro', 'compound_practice_random_besar_fixed', 'compound_besar_random_fixed'],
+        num_demo_participants=4,
     ),
 ]
 


### PR DESCRIPTION
## What & why

The `*_random` treatments never actually re-matched partners. `creating_session` was defined as a **method** of the `Subsession` class (`def creating_session(self):`), which oTree 5/6 does not call — so no re-grouping ran and oTree fell back to default stable grouping. Every "Random" session kept a **fixed partner for all 20 rounds**, identical to the Fixed arm, making the Fixed-vs-Random manipulation null by construction.

Verified against the raw oTree exports (distinct partners per subject = 1 in every random session, across multiple dates) and reproduced under oTree 6.0.10:

```
otree create_session compound_sedang_random        4  ->  distinct partners = [1,1,1,1]
otree create_session compound_sedang_random_fixed  4  ->  distinct partners = [2,2,2,2]
```

## What changed

Added bug-fixed twin apps for the three random treatments **and their practice apps**, each using a module-level hook:

```python
def creating_session(subsession: Subsession):
    subsession.group_randomly(fixed_id_in_group=True)
```

`fixed_id_in_group=True` re-matches partners every round while keeping each participant's role (Importir / Petugas Pajak) constant.

New apps:

| Stakes | Main | Practice |
|---|---|---|
| Kecil  | `compound_kecil_random_fixed`  | `compound_practice_random_kecil_fixed`  |
| Sedang | `compound_sedang_random_fixed` | `compound_practice_random_sedang_fixed` |
| Besar  | `compound_besar_random_fixed`  | `compound_practice_random_besar_fixed`  |

`settings.py`: three new session configs (`compound_{kecil,sedang,besar}_random_fixed`, `num_demo_participants=4`) wired to the **fixed** practice apps so practice also re-matches.

## Verification

Under oTree 6, 8-participant sessions for all three configs:
- Main apps (20 rounds): **4 distinct partners per subject** (= all available counterparts) — full re-matching.
- Practice apps (2 rounds): partners reshuffle between rounds.
- Roles fixed for every participant throughout.
- `otree resetdb` loads all apps cleanly.

## Scope / notes for reviewer

- **Originals left unchanged** (`compound_*_random`, `compound_practice_random_*`) and the **Fixed-matching apps were intentionally not touched** (their fallback already yields the intended fixed partner).
- This does **not** recover already-collected data — it only fixes future runs.
- Re-running under the new app names will shift the oTree wide-export column numbers, so the demography-extraction block in `cleaning.do` will need updated variable lists for any new data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)